### PR TITLE
Refinements to Linux version of desktop buddy

### DIFF
--- a/DesktopBuddy/Capture/DesktopStreamer.cs
+++ b/DesktopBuddy/Capture/DesktopStreamer.cs
@@ -24,6 +24,11 @@ public sealed class DesktopStreamer : IDisposable
     public bool IsResizeRecreatePending => _backend?.IsResizeRecreatePending ?? false;
     public uint LinuxPipeWireNodeId => _backend is ILinuxPipeWireSelection linux ? linux.PipeWireNodeId : 0;
     public ulong LinuxInputSessionId => _backend is ILinuxPipeWireSelection linux ? linux.InputSessionId : 0;
+    public ulong LinuxCaptureSessionId => _backend is ILinuxPipeWireSelection linux ? linux.CaptureSessionId : 0;
+    public int LinuxPositionX => _backend is ILinuxPipeWireSelection linux ? linux.PositionX : 0;
+    public int LinuxPositionY => _backend is ILinuxPipeWireSelection linux ? linux.PositionY : 0;
+    public int LinuxWorkspaceWidth => _backend is ILinuxPipeWireSelection linux ? linux.WorkspaceWidth : 0;
+    public int LinuxWorkspaceHeight => _backend is ILinuxPipeWireSelection linux ? linux.WorkspaceHeight : 0;
 
     public Action<IntPtr, IntPtr, int, int> OnGpuFrame
     {

--- a/DesktopBuddy/Capture/Linux/LinuxInputSessionManager.cs
+++ b/DesktopBuddy/Capture/Linux/LinuxInputSessionManager.cs
@@ -1,0 +1,114 @@
+using System;
+
+namespace DesktopBuddy;
+
+/// <summary>
+/// Owns the single RemoteDesktop session used for input injection across every panel.
+///
+/// Capture and input have to come from separate portal sessions: binding ScreenCast to a
+/// RemoteDesktop session makes xdg-desktop-portal-kde collapse source selection into one
+/// whole-workspace toggle, which is why individual monitors never appeared in the picker.
+///
+/// The input session still carries a workspace stream, because absolute pointer injection is
+/// addressed against a stream node. One session serves all panels, so this costs a single
+/// portal grant no matter how many screens are shared — fewer than the old design, which
+/// created one per panel.
+/// </summary>
+internal static class LinuxInputSessionManager
+{
+    private static readonly object Lock = new();
+    private static ulong _sessionId;
+    private static int _workspaceWidth;
+    private static int _workspaceHeight;
+
+    internal static ulong SessionId { get { lock (Lock) return _sessionId; } }
+    internal static int WorkspaceWidth { get { lock (Lock) return _workspaceWidth; } }
+    internal static int WorkspaceHeight { get { lock (Lock) return _workspaceHeight; } }
+
+    /// <summary>
+    /// Returns the shared input session, creating it on first use. The saved restore token
+    /// keeps this silent after the first approval.
+    /// </summary>
+    internal static ulong Ensure(out int workspaceWidth, out int workspaceHeight)
+    {
+        lock (Lock)
+        {
+            if (_sessionId != 0)
+            {
+                workspaceWidth = _workspaceWidth;
+                workspaceHeight = _workspaceHeight;
+                return _sessionId;
+            }
+        }
+
+        ulong id = 0;
+        int w = 0, h = 0;
+        try
+        {
+            string savedToken = DesktopBuddyMod.Config?.GetValue(DesktopBuddyMod.LinuxInputRestoreToken);
+            using var bridge = new LinuxNativeBridge();
+            id = bridge.SessionStart(string.IsNullOrEmpty(savedToken) ? null : savedToken,
+                out var selection, out string newToken, out _);
+            if (id != 0)
+            {
+                w = selection.Width > 0 ? (int)selection.Width : 0;
+                h = selection.Height > 0 ? (int)selection.Height : 0;
+
+                // The portal mints a fresh grant per start and never invalidates the old one,
+                // so the token we are replacing has to be revoked or it accumulates.
+                if (!string.IsNullOrEmpty(newToken) && newToken != savedToken)
+                {
+                    DesktopBuddyMod.SaveConfigValue(DesktopBuddyMod.LinuxInputRestoreToken, newToken);
+                    if (!string.IsNullOrEmpty(savedToken))
+                        bridge.PortalRevokeToken("remote-desktop", savedToken);
+                }
+                DesktopBuddyMod.Msg($"[LinuxInput] Shared input session {id} ready, workspace {w}x{h}");
+            }
+            else
+            {
+                DesktopBuddyMod.Msg("[LinuxInput] Shared input session could not be created; panels will capture without input");
+            }
+        }
+        catch (Exception ex) { DesktopBuddyMod.Msg($"[LinuxInput] Input session error: {ex.Message}"); }
+
+        lock (Lock)
+        {
+            if (_sessionId == 0 && id != 0)
+            {
+                _sessionId = id;
+                _workspaceWidth = w;
+                _workspaceHeight = h;
+            }
+            workspaceWidth = _workspaceWidth;
+            workspaceHeight = _workspaceHeight;
+            return _sessionId;
+        }
+    }
+
+    /// <summary>Closes the shared session once no panels remain.</summary>
+    internal static void Release()
+    {
+        ulong id;
+        lock (Lock)
+        {
+            if (_sessionId == 0) return;
+            id = _sessionId;
+            _sessionId = 0;
+            _workspaceWidth = 0;
+            _workspaceHeight = 0;
+        }
+
+        try
+        {
+            using var bridge = new LinuxNativeBridge();
+            int status = bridge.InputStop(id);
+            DesktopBuddyMod.Msg(status == 0
+                ? $"[LinuxInput] Released shared input session {id}"
+                : $"[LinuxInput] Shared input session {id} stop returned {status}: {bridge.GetInputLastError() ?? "(no error)"}");
+        }
+        catch (Exception ex) { DesktopBuddyMod.Msg($"[LinuxInput] Input session release error: {ex.Message}"); }
+
+        if (WindowInput.LinuxInputSession == id)
+            WindowInput.LinuxInputSession = 0;
+    }
+}

--- a/DesktopBuddy/Capture/Linux/LinuxNativeBridge.cs
+++ b/DesktopBuddy/Capture/Linux/LinuxNativeBridge.cs
@@ -33,7 +33,8 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
     private delegate* unmanaged[Cdecl]<ulong, uint, void> _inputTouchUp;
     private delegate* unmanaged[Cdecl]<ulong, int, void> _inputScroll;
     private delegate* unmanaged[Cdecl]<ulong, int, int, void> _inputKey;
-    private delegate* unmanaged[Cdecl]<ulong, void> _inputStop;
+    private delegate* unmanaged[Cdecl]<ulong, int> _inputStop;
+    private delegate* unmanaged[Cdecl]<byte*, nuint, int> _inputRevokeToken;
     private delegate* unmanaged[Cdecl]<IntPtr> _inputLastError;
     private IntPtr _module;
     private IntPtr _streamModule;
@@ -71,7 +72,8 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
             _inputTouchUp = (delegate* unmanaged[Cdecl]<ulong, uint, void>)NativeLibrary.GetExport(_module, "db_linux_input_touch_up");
             _inputScroll = (delegate* unmanaged[Cdecl]<ulong, int, void>)NativeLibrary.GetExport(_module, "db_linux_input_scroll");
             _inputKey = (delegate* unmanaged[Cdecl]<ulong, int, int, void>)NativeLibrary.GetExport(_module, "db_linux_input_key");
-            _inputStop = (delegate* unmanaged[Cdecl]<ulong, void>)NativeLibrary.GetExport(_module, "db_linux_input_stop");
+            _inputStop = (delegate* unmanaged[Cdecl]<ulong, int>)NativeLibrary.GetExport(_module, "db_linux_input_stop");
+            _inputRevokeToken = (delegate* unmanaged[Cdecl]<byte*, nuint, int>)NativeLibrary.GetExport(_module, "db_linux_input_revoke_token");
             _inputLastError = (delegate* unmanaged[Cdecl]<IntPtr>)NativeLibrary.GetExport(_module, "db_linux_input_last_error");
             Log.Msg($"[LinuxNativeBridge] Loaded {nativePath}");
             return true;
@@ -101,9 +103,29 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
             _inputScroll = null;
             _inputKey = null;
             _inputStop = null;
+            _inputRevokeToken = null;
             _inputLastError = null;
             return false;
         }
+    }
+
+    /// <summary>
+    /// Revokes a persisted portal grant so it stops appearing in the desktop's remembered
+    /// screen-sharing permissions. Call whenever a restore token is superseded or discarded.
+    /// </summary>
+    internal bool InputRevokeToken(string restoreToken)
+    {
+        if (string.IsNullOrEmpty(restoreToken)) return false;
+        if (!TryLoad() || _inputRevokeToken == null) return false;
+
+        byte[] tokenBytes = System.Text.Encoding.UTF8.GetBytes(restoreToken);
+        int status;
+        fixed (byte* tok = tokenBytes)
+            status = _inputRevokeToken(tok, (nuint)tokenBytes.Length);
+
+        if (status != 0)
+            Log.Msg($"[LinuxNativeBridge] Revoke token failed status={status}: {GetInputLastError() ?? "(none)"}");
+        return status == 0;
     }
 
     internal ulong SessionStart(string restoreToken, out DbLinuxSelection selection, out string newRestoreToken,
@@ -184,10 +206,20 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
         _inputKey(sessionId, keysym, pressed ? 1 : 0);
     }
 
-    internal void InputStop(ulong sessionId)
+    /// <summary>
+    /// Stops a portal session. Returns the native status: 0 when the portal confirmed the
+    /// close, 1 if the worker ended without reaching it, -1 if the session was not
+    /// registered, -2 if the close failed, -3 on lock poisoning. Returns -10 when the native
+    /// library is unavailable, which is distinct from anything the native side reports.
+    /// </summary>
+    internal int InputStop(ulong sessionId)
     {
-        if (_inputStop == null || sessionId == 0) return;
-        _inputStop(sessionId);
+        if (sessionId == 0) return -10;
+        // Callers routinely build a bridge purely to stop a session (cleanup does), so the
+        // library has to be loaded here. Without this the delegate is still null and the
+        // session is silently never closed, leaking the portal grant.
+        if (!TryLoad() || _inputStop == null) return -10;
+        return _inputStop(sessionId);
     }
 
     internal int StartCapture(uint nodeId, out ulong captureId)

--- a/DesktopBuddy/Capture/Linux/LinuxNativeBridge.cs
+++ b/DesktopBuddy/Capture/Linux/LinuxNativeBridge.cs
@@ -33,8 +33,13 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
     private delegate* unmanaged[Cdecl]<ulong, uint, void> _inputTouchUp;
     private delegate* unmanaged[Cdecl]<ulong, int, void> _inputScroll;
     private delegate* unmanaged[Cdecl]<ulong, int, int, void> _inputKey;
+    private delegate* unmanaged[Cdecl]<ulong, int, int, void> _inputButton;
     private delegate* unmanaged[Cdecl]<ulong, int> _inputStop;
     private delegate* unmanaged[Cdecl]<byte*, nuint, int> _inputRevokeToken;
+    private delegate* unmanaged[Cdecl]<byte*, nuint, ulong*, DbLinuxSelection*, int> _screencastStart;
+    private delegate* unmanaged[Cdecl]<ulong, int> _screencastStop;
+    private delegate* unmanaged[Cdecl]<byte*, nuint, byte*, nuint, int> _portalRevokeToken;
+    private delegate* unmanaged[Cdecl]<int, int, int, int, byte*, nuint, int> _kwinOutputName;
     private delegate* unmanaged[Cdecl]<byte*, nuint, int> _kwinEffectLoaded;
     private delegate* unmanaged[Cdecl]<byte*, nuint, int, int> _kwinEffectSet;
     private delegate* unmanaged[Cdecl]<IntPtr> _inputLastError;
@@ -74,8 +79,13 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
             _inputTouchUp = (delegate* unmanaged[Cdecl]<ulong, uint, void>)NativeLibrary.GetExport(_module, "db_linux_input_touch_up");
             _inputScroll = (delegate* unmanaged[Cdecl]<ulong, int, void>)NativeLibrary.GetExport(_module, "db_linux_input_scroll");
             _inputKey = (delegate* unmanaged[Cdecl]<ulong, int, int, void>)NativeLibrary.GetExport(_module, "db_linux_input_key");
+            _inputButton = (delegate* unmanaged[Cdecl]<ulong, int, int, void>)NativeLibrary.GetExport(_module, "db_linux_input_button");
             _inputStop = (delegate* unmanaged[Cdecl]<ulong, int>)NativeLibrary.GetExport(_module, "db_linux_input_stop");
             _inputRevokeToken = (delegate* unmanaged[Cdecl]<byte*, nuint, int>)NativeLibrary.GetExport(_module, "db_linux_input_revoke_token");
+            _screencastStart = (delegate* unmanaged[Cdecl]<byte*, nuint, ulong*, DbLinuxSelection*, int>)NativeLibrary.GetExport(_module, "db_linux_screencast_start");
+            _screencastStop = (delegate* unmanaged[Cdecl]<ulong, int>)NativeLibrary.GetExport(_module, "db_linux_screencast_stop");
+            _portalRevokeToken = (delegate* unmanaged[Cdecl]<byte*, nuint, byte*, nuint, int>)NativeLibrary.GetExport(_module, "db_linux_portal_revoke_token");
+            _kwinOutputName = (delegate* unmanaged[Cdecl]<int, int, int, int, byte*, nuint, int>)NativeLibrary.GetExport(_module, "db_linux_kwin_output_name");
             _kwinEffectLoaded = (delegate* unmanaged[Cdecl]<byte*, nuint, int>)NativeLibrary.GetExport(_module, "db_linux_kwin_effect_loaded");
             _kwinEffectSet = (delegate* unmanaged[Cdecl]<byte*, nuint, int, int>)NativeLibrary.GetExport(_module, "db_linux_kwin_effect_set");
             _inputLastError = (delegate* unmanaged[Cdecl]<IntPtr>)NativeLibrary.GetExport(_module, "db_linux_input_last_error");
@@ -106,13 +116,104 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
             _inputTouchUp = null;
             _inputScroll = null;
             _inputKey = null;
+            _inputButton = null;
             _inputStop = null;
             _inputRevokeToken = null;
+            _screencastStart = null;
+            _screencastStop = null;
+            _portalRevokeToken = null;
+            _kwinOutputName = null;
             _kwinEffectLoaded = null;
             _kwinEffectSet = null;
             _inputLastError = null;
             return false;
         }
+    }
+
+    /// <summary>
+    /// Opens the ScreenCast picker (or restores silently with a token) and keeps the session
+    /// alive until <see cref="ScreencastStop"/>. Unlike the combined RemoteDesktop session,
+    /// this offers each monitor separately. Returns the session id, or 0 on failure.
+    /// </summary>
+    internal ulong ScreencastStart(string restoreToken, out DbLinuxSelection selection,
+        out string newRestoreToken, out bool isMonitor)
+    {
+        selection = default;
+        newRestoreToken = null;
+        isMonitor = false;
+        if (!TryLoad() || _screencastStart == null) return 0;
+
+        byte[] tokenBytes = string.IsNullOrEmpty(restoreToken)
+            ? null
+            : Encoding.UTF8.GetBytes(restoreToken);
+
+        ulong id = 0;
+        int status;
+        fixed (DbLinuxSelection* selPtr = &selection)
+        fixed (byte* tok = tokenBytes)
+            status = _screencastStart(tok, (nuint)(tokenBytes?.Length ?? 0), &id, selPtr);
+
+        if (status != 0 || id == 0)
+        {
+            Log.Msg($"[LinuxNativeBridge] Screencast start failed status={status}: {GetInputLastError() ?? "(none)"}");
+            return 0;
+        }
+
+        if (selection.RestoreTokenLen > 0)
+        {
+            int len = (int)Math.Min(selection.RestoreTokenLen, 256u);
+            fixed (byte* p = selection.RestoreToken)
+                newRestoreToken = Encoding.UTF8.GetString(p, len);
+        }
+        isMonitor = selection.IsMonitor != 0;
+        return id;
+    }
+
+    /// <summary>Stops a capture session and closes its portal session.</summary>
+    internal int ScreencastStop(ulong sessionId)
+    {
+        if (sessionId == 0) return -10;
+        if (!TryLoad() || _screencastStop == null) return -10;
+        return _screencastStop(sessionId);
+    }
+
+    /// <summary>
+    /// Revokes a persisted grant from a specific permission-store table. RemoteDesktop grants
+    /// live in "remote-desktop" and ScreenCast grants in "screencast".
+    /// </summary>
+    internal bool PortalRevokeToken(string table, string restoreToken)
+    {
+        if (string.IsNullOrEmpty(table) || string.IsNullOrEmpty(restoreToken)) return false;
+        if (!TryLoad() || _portalRevokeToken == null) return false;
+
+        byte[] tableBytes = Encoding.UTF8.GetBytes(table);
+        byte[] tokenBytes = Encoding.UTF8.GetBytes(restoreToken);
+        int status;
+        fixed (byte* t = tableBytes)
+        fixed (byte* k = tokenBytes)
+            status = _portalRevokeToken(t, (nuint)tableBytes.Length, k, (nuint)tokenBytes.Length);
+
+        if (status != 0)
+            Log.Msg($"[LinuxNativeBridge] Revoke {table} token failed status={status}: {GetInputLastError() ?? "(none)"}");
+        return status == 0;
+    }
+
+    /// <summary>
+    /// Returns the compositor's connector name for the output at the given geometry
+    /// ("DP-5", "HDMI-A-1", ...), or null when nothing matches or KWin is unavailable.
+    /// The ScreenCast portal never reports an output name, so it is recovered by matching
+    /// the captured geometry against what the compositor reports.
+    /// </summary>
+    internal string KWinOutputName(int x, int y, int width, int height)
+    {
+        if (!TryLoad() || _kwinOutputName == null) return null;
+
+        byte[] buffer = new byte[64];
+        int len;
+        fixed (byte* p = buffer)
+            len = _kwinOutputName(x, y, width, height, p, (nuint)buffer.Length);
+
+        return len > 0 ? Encoding.UTF8.GetString(buffer, 0, len) : null;
     }
 
     /// <summary>
@@ -248,6 +349,13 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
     /// registered, -2 if the close failed, -3 on lock poisoning. Returns -10 when the native
     /// library is unavailable, which is distinct from anything the native side reports.
     /// </summary>
+    /// <summary>Presses or releases a pointer button (evdev code; BTN_RIGHT is 0x111).</summary>
+    internal void InputButton(ulong sessionId, int button, bool pressed)
+    {
+        if (_inputButton == null || sessionId == 0) return;
+        _inputButton(sessionId, button, pressed ? 1 : 0);
+    }
+
     internal int InputStop(ulong sessionId)
     {
         if (sessionId == 0) return -10;
@@ -581,6 +689,13 @@ internal unsafe struct DbLinuxSelection
     public uint IsMonitor;
     public uint RestoreTokenLen;
     public fixed byte RestoreToken[256];
+    /// <summary>
+    /// Offset of the captured source in compositor coordinates. Non-zero for a monitor that
+    /// is not the leftmost one, and needed to map panel input onto the workspace when capture
+    /// and input come from separate portal sessions.
+    /// </summary>
+    public int PositionX;
+    public int PositionY;
 }
 
 [StructLayout(LayoutKind.Sequential)]

--- a/DesktopBuddy/Capture/Linux/LinuxNativeBridge.cs
+++ b/DesktopBuddy/Capture/Linux/LinuxNativeBridge.cs
@@ -11,6 +11,7 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
     private delegate* unmanaged[Cdecl]<ulong, DbLinuxFrame*, int> _pollFrame;
     private delegate* unmanaged[Cdecl]<ulong, void> _stopCapture;
     private delegate* unmanaged[Cdecl]<ulong, int> _captureAlive;
+    private delegate* unmanaged[Cdecl]<uint, int> _nodeExists;
     private delegate* unmanaged[Cdecl]<DbLinuxFrame*, byte*, UIntPtr, int> _copyAndCloseFrame;
     private delegate* unmanaged[Cdecl]<DbLinuxFrame*, void> _closeFrame;
     private delegate* unmanaged[Cdecl]<ulong*, int> _audioStart;
@@ -67,6 +68,7 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
             _pollFrame = (delegate* unmanaged[Cdecl]<ulong, DbLinuxFrame*, int>)NativeLibrary.GetExport(_module, "db_linux_capture_poll");
             _stopCapture = (delegate* unmanaged[Cdecl]<ulong, void>)NativeLibrary.GetExport(_module, "db_linux_capture_stop");
             _captureAlive = (delegate* unmanaged[Cdecl]<ulong, int>)NativeLibrary.GetExport(_module, "db_linux_capture_alive");
+            _nodeExists = (delegate* unmanaged[Cdecl]<uint, int>)NativeLibrary.GetExport(_module, "db_linux_node_exists");
             _copyAndCloseFrame = (delegate* unmanaged[Cdecl]<DbLinuxFrame*, byte*, UIntPtr, int>)NativeLibrary.GetExport(_module, "db_linux_frame_copy_and_close");
             _closeFrame = (delegate* unmanaged[Cdecl]<DbLinuxFrame*, void>)NativeLibrary.GetExport(_module, "db_linux_frame_close");
             _audioStart = (delegate* unmanaged[Cdecl]<ulong*, int>)NativeLibrary.GetExport(_module, "db_linux_audio_start");
@@ -104,6 +106,7 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
             _pollFrame = null;
             _stopCapture = null;
             _captureAlive = null;
+            _nodeExists = null;
             _copyAndCloseFrame = null;
             _closeFrame = null;
             _audioStart = null;
@@ -398,6 +401,18 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
         return _captureAlive(captureId) != 0;
     }
 
+    /// <summary>
+    /// Asks PipeWire whether <paramref name="nodeId"/> is a live node right now. Returns false
+    /// only for a definite "no"; if the check itself cannot run or the server does not answer,
+    /// this returns true so callers behave as they did before rather than discarding a source
+    /// on the strength of a failed lookup.
+    /// </summary>
+    internal bool NodeExists(uint nodeId)
+    {
+        if (!TryLoad() || _nodeExists == null) return true;
+        return _nodeExists(nodeId) != 0;
+    }
+
     internal int CopyAndCloseFrame(DbLinuxFrame frame, byte[] destination)
     {
         if (!TryLoad() || _copyAndCloseFrame == null || destination == null || destination.Length == 0)
@@ -643,6 +658,7 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
         _pollFrame = null;
         _stopCapture = null;
         _captureAlive = null;
+        _nodeExists = null;
         _copyAndCloseFrame = null;
         _closeFrame = null;
         _audioStart = null;

--- a/DesktopBuddy/Capture/Linux/LinuxNativeBridge.cs
+++ b/DesktopBuddy/Capture/Linux/LinuxNativeBridge.cs
@@ -35,6 +35,8 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
     private delegate* unmanaged[Cdecl]<ulong, int, int, void> _inputKey;
     private delegate* unmanaged[Cdecl]<ulong, int> _inputStop;
     private delegate* unmanaged[Cdecl]<byte*, nuint, int> _inputRevokeToken;
+    private delegate* unmanaged[Cdecl]<byte*, nuint, int> _kwinEffectLoaded;
+    private delegate* unmanaged[Cdecl]<byte*, nuint, int, int> _kwinEffectSet;
     private delegate* unmanaged[Cdecl]<IntPtr> _inputLastError;
     private IntPtr _module;
     private IntPtr _streamModule;
@@ -74,6 +76,8 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
             _inputKey = (delegate* unmanaged[Cdecl]<ulong, int, int, void>)NativeLibrary.GetExport(_module, "db_linux_input_key");
             _inputStop = (delegate* unmanaged[Cdecl]<ulong, int>)NativeLibrary.GetExport(_module, "db_linux_input_stop");
             _inputRevokeToken = (delegate* unmanaged[Cdecl]<byte*, nuint, int>)NativeLibrary.GetExport(_module, "db_linux_input_revoke_token");
+            _kwinEffectLoaded = (delegate* unmanaged[Cdecl]<byte*, nuint, int>)NativeLibrary.GetExport(_module, "db_linux_kwin_effect_loaded");
+            _kwinEffectSet = (delegate* unmanaged[Cdecl]<byte*, nuint, int, int>)NativeLibrary.GetExport(_module, "db_linux_kwin_effect_set");
             _inputLastError = (delegate* unmanaged[Cdecl]<IntPtr>)NativeLibrary.GetExport(_module, "db_linux_input_last_error");
             Log.Msg($"[LinuxNativeBridge] Loaded {nativePath}");
             return true;
@@ -104,9 +108,41 @@ internal sealed unsafe class LinuxNativeBridge : IDisposable
             _inputKey = null;
             _inputStop = null;
             _inputRevokeToken = null;
+            _kwinEffectLoaded = null;
+            _kwinEffectSet = null;
             _inputLastError = null;
             return false;
         }
+    }
+
+    /// <summary>
+    /// Returns 1 if the named KWin effect is loaded, 0 if not, negative if KWin is
+    /// unavailable (any non-KDE desktop, where this is simply not applicable).
+    /// </summary>
+    internal int KWinEffectLoaded(string effect)
+    {
+        if (string.IsNullOrEmpty(effect)) return -1;
+        if (!TryLoad() || _kwinEffectLoaded == null) return -1;
+
+        byte[] bytes = Encoding.UTF8.GetBytes(effect);
+        fixed (byte* p = bytes)
+            return _kwinEffectLoaded(p, (nuint)bytes.Length);
+    }
+
+    /// <summary>Loads or unloads a KWin effect at runtime. Returns true on success.</summary>
+    internal bool KWinEffectSet(string effect, bool load)
+    {
+        if (string.IsNullOrEmpty(effect)) return false;
+        if (!TryLoad() || _kwinEffectSet == null) return false;
+
+        byte[] bytes = Encoding.UTF8.GetBytes(effect);
+        int status;
+        fixed (byte* p = bytes)
+            status = _kwinEffectSet(p, (nuint)bytes.Length, load ? 1 : 0);
+
+        if (status != 0)
+            Log.Msg($"[LinuxNativeBridge] KWin effect {(load ? "load" : "unload")} '{effect}' failed status={status}: {GetInputLastError() ?? "(none)"}");
+        return status == 0;
     }
 
     /// <summary>

--- a/DesktopBuddy/Capture/Linux/LinuxPortalCaptureBackend.cs
+++ b/DesktopBuddy/Capture/Linux/LinuxPortalCaptureBackend.cs
@@ -6,6 +6,11 @@ internal interface ILinuxPipeWireSelection
 {
     uint PipeWireNodeId { get; }
     ulong InputSessionId { get; }
+    ulong CaptureSessionId { get; }
+    int PositionX { get; }
+    int PositionY { get; }
+    int WorkspaceWidth { get; }
+    int WorkspaceHeight { get; }
 }
 
 internal sealed class LinuxPortalCaptureBackend : IDesktopCaptureBackend, ILinuxPipeWireSelection
@@ -16,6 +21,11 @@ internal sealed class LinuxPortalCaptureBackend : IDesktopCaptureBackend, ILinux
     public int Height { get; private set; }
     public uint PipeWireNodeId { get; private set; }
     public ulong InputSessionId { get; private set; }
+    public ulong CaptureSessionId { get; private set; }
+    public int PositionX { get; private set; }
+    public int PositionY { get; private set; }
+    public int WorkspaceWidth { get; private set; }
+    public int WorkspaceHeight { get; private set; }
     public bool IsValid => _running;
     public object D3dContextLock => null;
     public IntPtr D3dDevice => IntPtr.Zero;
@@ -38,10 +48,17 @@ internal sealed class LinuxPortalCaptureBackend : IDesktopCaptureBackend, ILinux
 
         PipeWireNodeId = selection.NodeId;
         InputSessionId = selection.InputSessionId;
+        CaptureSessionId = selection.CaptureSessionId;
+        PositionX = selection.PositionX;
+        PositionY = selection.PositionY;
+        WorkspaceWidth = selection.WorkspaceWidth;
+        WorkspaceHeight = selection.WorkspaceHeight;
         Width = selection.Width > 0 ? selection.Width : 1280;
         Height = selection.Height > 0 ? selection.Height : 720;
         _running = true;
-        Log.Msg($"[LinuxPortalCapture] Using selected PipeWire node={PipeWireNodeId} size={Width}x{Height} inputSession={InputSessionId}");
+        Log.Msg($"[LinuxPortalCapture] Using selected PipeWire node={PipeWireNodeId} size={Width}x{Height} " +
+            $"pos=({PositionX},{PositionY}) workspace={WorkspaceWidth}x{WorkspaceHeight} " +
+            $"captureSession={CaptureSessionId} inputSession={InputSessionId}");
         return true;
     }
 

--- a/DesktopBuddy/Capture/Linux/LinuxPortalSelectionStore.cs
+++ b/DesktopBuddy/Capture/Linux/LinuxPortalSelectionStore.cs
@@ -6,14 +6,35 @@ internal readonly struct LinuxPortalSelection
     public readonly int Width;
     public readonly int Height;
 
+    /// <summary>Shared RemoteDesktop session used for input; not owned by this capture.</summary>
     public readonly ulong InputSessionId;
 
-    public LinuxPortalSelection(uint nodeId, int width, int height, ulong inputSessionId = 0)
+    /// <summary>ScreenCast session owning this capture's stream; stopped when the panel closes.</summary>
+    public readonly ulong CaptureSessionId;
+
+    /// <summary>
+    /// Where the captured source sits in compositor coordinates, and how big the whole
+    /// workspace is. Input is injected against the workspace stream, so panel-local
+    /// coordinates have to be offset into that space before they are sent.
+    /// </summary>
+    public readonly int PositionX;
+    public readonly int PositionY;
+    public readonly int WorkspaceWidth;
+    public readonly int WorkspaceHeight;
+
+    public LinuxPortalSelection(uint nodeId, int width, int height, ulong inputSessionId = 0,
+        ulong captureSessionId = 0, int positionX = 0, int positionY = 0,
+        int workspaceWidth = 0, int workspaceHeight = 0)
     {
         NodeId = nodeId;
         Width = width;
         Height = height;
         InputSessionId = inputSessionId;
+        CaptureSessionId = captureSessionId;
+        PositionX = positionX;
+        PositionY = positionY;
+        WorkspaceWidth = workspaceWidth;
+        WorkspaceHeight = workspaceHeight;
     }
 }
 

--- a/DesktopBuddy/Capture/Linux/LinuxSessionLifetime.cs
+++ b/DesktopBuddy/Capture/Linux/LinuxSessionLifetime.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DesktopBuddy;
+
+/// <summary>
+/// Releases the shared RemoteDesktop input session once no panels remain.
+///
+/// Like the cursor-effect suspender this is driven from the live session count rather than
+/// from open/close hooks, because sessions are removed from <c>ActiveSessions</c> in several
+/// places and not all of them run cleanup.
+/// </summary>
+internal static class LinuxSessionLifetime
+{
+    private static readonly object Lock = new();
+    private static bool _busy;
+
+    internal static void Sync(int activeShareCount)
+    {
+        if (!DesktopBuddyPlatform.IsLinux) return;
+        if (activeShareCount > 0) return;
+        if (LinuxInputSessionManager.SessionId == 0) return;
+
+        lock (Lock)
+        {
+            if (_busy) return;
+            _busy = true;
+        }
+
+        // Closing the portal session is a D-Bus round trip; keep it off the update loop.
+        Task.Run(() =>
+        {
+            try { LinuxInputSessionManager.Release(); }
+            catch (Exception ex) { DesktopBuddyMod.Msg($"[LinuxInput] Release failed: {ex.Message}"); }
+            finally { lock (Lock) { _busy = false; } }
+        });
+    }
+}

--- a/DesktopBuddy/Capture/Wgc/WgcDeviceManager.cs
+++ b/DesktopBuddy/Capture/Wgc/WgcDeviceManager.cs
@@ -16,6 +16,9 @@ public sealed partial class WgcCapture
     internal static unsafe List<GpuAdapterInfo> EnumerateAdapters()
     {
         var adapters = new List<GpuAdapterInfo>();
+        if (DesktopBuddyPlatform.IsLinux)
+            return adapters;
+
         var factoryGuid = new Guid("770aae78-f26f-4dba-a829-253c83d1b387");
         int hr = CreateDXGIFactory1(ref factoryGuid, out IntPtr factory);
         if (hr < 0 || factory == IntPtr.Zero)

--- a/DesktopBuddy/Configuration/ModConfig.Keys.cs
+++ b/DesktopBuddy/Configuration/ModConfig.Keys.cs
@@ -53,6 +53,12 @@ public partial class DesktopBuddyMod
         new("panelCurvePreferences", "Saved DesktopBuddy panel curve values, keyed by application executable path or shared desktop capture.", () => "");
     internal static readonly DesktopBuddyConfigKey<string> LinuxSharedSources =
         new("linuxSharedSources", "Saved Linux desktop/window sources for instant re-share, with their restore tokens and icons.", () => "");
+    internal static readonly DesktopBuddyConfigKey<float> StickScrollSpeed =
+        new("stickScrollSpeed", "Controller thumbstick scroll speed, in wheel notches per second at full deflection.", () => 8.0f);
+    internal static readonly DesktopBuddyConfigKey<bool> LinuxPointerInput =
+        new("linuxPointerInput", "Send laser interaction as real mouse button events instead of touchscreen events. Touch mode makes apps treat the panel as a touchscreen: drag pans instead of selecting text, press-and-hold opens context menus, and some shell surfaces ignore it entirely.", () => true);
+    internal static readonly DesktopBuddyConfigKey<string> LinuxInputRestoreToken =
+        new("linuxInputRestoreToken", "Portal restore token for the shared Linux input session, so input permission is only asked for once.", () => "");
     internal static readonly DesktopBuddyConfigKey<bool> LinuxSuspendShakeCursor =
         new("linuxSuspendShakeCursor", "Suspend KWin's shake-cursor effect while sharing, so laser and mouse input do not magnify the cursor (KDE only).", () => true);
     internal static readonly DesktopBuddyConfigKey<string> ViewerCullingMode =

--- a/DesktopBuddy/Configuration/ModConfig.Keys.cs
+++ b/DesktopBuddy/Configuration/ModConfig.Keys.cs
@@ -53,6 +53,8 @@ public partial class DesktopBuddyMod
         new("panelCurvePreferences", "Saved DesktopBuddy panel curve values, keyed by application executable path or shared desktop capture.", () => "");
     internal static readonly DesktopBuddyConfigKey<string> LinuxSharedSources =
         new("linuxSharedSources", "Saved Linux desktop/window sources for instant re-share, with their restore tokens and icons.", () => "");
+    internal static readonly DesktopBuddyConfigKey<bool> LinuxSuspendShakeCursor =
+        new("linuxSuspendShakeCursor", "Suspend KWin's shake-cursor effect while sharing, so laser and mouse input do not magnify the cursor (KDE only).", () => true);
     internal static readonly DesktopBuddyConfigKey<string> ViewerCullingMode =
         new("viewerCullingMode", "Viewer culling mode for remote streams: frustum or distance.", () => "frustum");
     internal static readonly DesktopBuddyConfigKey<bool> ViewerCullingPreview =

--- a/DesktopBuddy/Configuration/ModConfig.Keys.cs
+++ b/DesktopBuddy/Configuration/ModConfig.Keys.cs
@@ -53,6 +53,8 @@ public partial class DesktopBuddyMod
         new("panelCurvePreferences", "Saved DesktopBuddy panel curve values, keyed by application executable path or shared desktop capture.", () => "");
     internal static readonly DesktopBuddyConfigKey<string> LinuxSharedSources =
         new("linuxSharedSources", "Saved Linux desktop/window sources for instant re-share, with their restore tokens and icons.", () => "");
+    internal static readonly DesktopBuddyConfigKey<float> SpawnTilt =
+        new("spawnTilt", "Tilt of newly spawned panels, in degrees. Positive leans the top away from you like a monitor on a stand; negative tips it towards you, which reads better on a panel spawned above eye level. 0 is upright.", () => 0.0f);
     internal static readonly DesktopBuddyConfigKey<float> StickScrollSpeed =
         new("stickScrollSpeed", "Controller thumbstick scroll speed, in wheel notches per second at full deflection.", () => 8.0f);
     internal static readonly DesktopBuddyConfigKey<bool> LinuxPointerInput =

--- a/DesktopBuddy/Input/Window/WindowInput.Linux.cs
+++ b/DesktopBuddy/Input/Window/WindowInput.Linux.cs
@@ -7,6 +7,48 @@ public static partial class WindowInput
 
     internal static ulong LinuxInputSession;
 
+    /// <summary>
+    /// Captured region of the focused panel, in compositor coordinates, plus the workspace
+    /// size. Input is injected against the workspace stream of the shared RemoteDesktop
+    /// session, but panel coordinates are relative to the captured source, so they have to be
+    /// offset into workspace space. Zero workspace values mean "capture is the whole
+    /// workspace", where the mapping is the identity.
+    /// </summary>
+    internal static int LinuxCaptureX, LinuxCaptureY;
+    internal static int LinuxCaptureW, LinuxCaptureH;
+    internal static int LinuxWorkspaceW, LinuxWorkspaceH;
+
+    internal static void SetLinuxInputTarget(ulong sessionId, int captureX, int captureY,
+        int captureW, int captureH, int workspaceW, int workspaceH)
+    {
+        LinuxInputSession = sessionId;
+        LinuxCaptureX = captureX;
+        LinuxCaptureY = captureY;
+        LinuxCaptureW = captureW;
+        LinuxCaptureH = captureH;
+        LinuxWorkspaceW = workspaceW;
+        LinuxWorkspaceH = workspaceH;
+    }
+
+    /// <summary>Maps panel-local normalized coordinates onto workspace-normalized ones.</summary>
+    private static void MapToWorkspace(float u, float v, out double outU, out double outV)
+    {
+        int ws = LinuxWorkspaceW, hs = LinuxWorkspaceH;
+        int cw = LinuxCaptureW, ch = LinuxCaptureH;
+
+        if (ws <= 0 || hs <= 0 || cw <= 0 || ch <= 0)
+        {
+            outU = u;
+            outV = v;
+            return;
+        }
+
+        double globalX = LinuxCaptureX + (double)u * cw;
+        double globalY = LinuxCaptureY + (double)v * ch;
+        outU = globalX / ws;
+        outV = globalY / hs;
+    }
+
     private static LinuxNativeBridge _linuxInput;
     private static readonly object _linuxInputLock = new();
 
@@ -28,7 +70,9 @@ public static partial class WindowInput
     internal static void LinuxMove(float u, float v)
     {
         ulong s = LinuxInputSession;
-        if (s != 0) LinuxInput().InputMotion(s, u, v);
+        if (s == 0) return;
+        MapToWorkspace(u, v, out double mu, out double mv);
+        LinuxInput().InputMotion(s, mu, mv);
     }
 
     internal static void LinuxTouchDown(uint slot, float u, float v)
@@ -36,7 +80,16 @@ public static partial class WindowInput
         ulong s = LinuxInputSession;
         if (s == 0) return;
         var b = LinuxInput();
-        int rc = b.TouchDown(s, slot, u, v);
+        MapToWorkspace(u, v, out double mu, out double mv);
+
+        if (PointerMode)
+        {
+            b.InputMotion(s, mu, mv);
+            b.InputButton(s, BtnLeft, true);
+            return;
+        }
+
+        int rc = b.TouchDown(s, slot, mu, mv);
         if (rc != 0)
             Log.Msg($"[LinuxInput] touch down rc={rc} session={s} slot={slot} err={b.GetInputLastError() ?? "(none)"}");
     }
@@ -44,13 +97,50 @@ public static partial class WindowInput
     internal static void LinuxTouchMove(uint slot, float u, float v)
     {
         ulong s = LinuxInputSession;
-        if (s != 0) LinuxInput().TouchMotion(s, slot, u, v);
+        if (s == 0) return;
+        MapToWorkspace(u, v, out double mu, out double mv);
+        var b = LinuxInput();
+
+        // In pointer mode a drag is just motion with the button already held, which is what
+        // makes click-and-drag select text the way a real mouse does.
+        if (PointerMode) { b.InputMotion(s, mu, mv); return; }
+
+        b.TouchMotion(s, slot, mu, mv);
     }
 
     internal static void LinuxTouchUp(uint slot)
     {
         ulong s = LinuxInputSession;
-        if (s != 0) LinuxInput().TouchUp(s, slot);
+        if (s == 0) return;
+        var b = LinuxInput();
+        if (PointerMode) { b.InputButton(s, BtnLeft, false); return; }
+        b.TouchUp(s, slot);
+    }
+
+    private const int BtnLeft = 0x110;
+    private const int BtnRight = 0x111;
+
+    /// <summary>
+    /// True when interaction should be sent as mouse buttons rather than touch contacts.
+    ///
+    /// The portal offers both, and they are not interchangeable from the application's point
+    /// of view: a touch contact makes apps engage their touchscreen behaviour (drag pans
+    /// instead of selecting, press-and-hold opens a context menu), and some shell surfaces
+    /// such as the tray and task manager do not accept touch at all.
+    /// </summary>
+    private static bool PointerMode =>
+        DesktopBuddyMod.Config?.GetValue(DesktopBuddyMod.LinuxPointerInput) ?? true;
+
+    /// <summary>Moves the pointer to the panel point and issues a full right-click there.</summary>
+    internal static void LinuxRightClick(float u, float v)
+    {
+        ulong s = LinuxInputSession;
+        if (s == 0) return;
+        var b = LinuxInput();
+        MapToWorkspace(u, v, out double mu, out double mv);
+        b.InputMotion(s, mu, mv);
+        b.InputButton(s, BtnRight, true);
+        b.InputButton(s, BtnRight, false);
     }
 
     internal static void LinuxScroll(int wheelDelta)

--- a/DesktopBuddy/Input/Window/WindowInput.Touch.cs
+++ b/DesktopBuddy/Input/Window/WindowInput.Touch.cs
@@ -118,6 +118,16 @@ public static partial class WindowInput
         }
     }
 
+    /// <summary>
+    /// Issues a right-click at the given panel point. Linux only for now: the Windows path is
+    /// entirely touch-based and has no secondary-button equivalent.
+    /// </summary>
+    public static void SendRightClick(IntPtr hWnd, float u, float v, int clientW, int clientH, IntPtr monitorHandle = default)
+    {
+        if (DesktopBuddyPlatform.IsLinux) { LinuxRightClick(u, v); return; }
+        Log.Msg("[Input] Right-click is not implemented on this platform");
+    }
+
     public static void SendScroll(IntPtr hWnd, float u, float v, int clientW, int clientH, int wheelDelta, IntPtr monitorHandle = default)
     {
         if (DesktopBuddyPlatform.IsLinux) { LinuxMove(u, v); LinuxScroll(wheelDelta); return; }

--- a/DesktopBuddy/Sessions/DesktopSession.cs
+++ b/DesktopBuddy/Sessions/DesktopSession.cs
@@ -23,6 +23,19 @@ public class DesktopSession
     public Component LastActiveSource;
     public HashSet<uint> ActiveTouchIds = new();
 
+    /// <summary>
+    /// Panel is pinned: its Grabbable is disabled so it cannot be moved, which frees the grab
+    /// action to act as right-click instead.
+    /// </summary>
+    public bool PanelLocked;
+    public double LastGrabTick;
+
+    /// <summary>
+    /// Fractional wheel notches banked from thumbstick deflection. Scrolling is accumulated
+    /// over time rather than emitted per frame, so the speed does not scale with framerate.
+    /// </summary>
+    public float StickScrollAccum;
+
     public int LastScrollSign;
     public double LastScrollTick;
 
@@ -69,6 +82,16 @@ public class DesktopSession
     public DesktopKeyboardSource KeyboardSource;
 
     public ulong LinuxInputSessionId;
+
+    /// <summary>ScreenCast session owning this panel's capture stream; closed on cleanup.</summary>
+    public ulong LinuxCaptureSessionId;
+
+    /// <summary>
+    /// Captured region in compositor coordinates plus the workspace size, used to translate
+    /// panel-local input into the workspace space the input session addresses.
+    /// </summary>
+    public int LinuxPositionX, LinuxPositionY;
+    public int LinuxWorkspaceWidth, LinuxWorkspaceHeight;
 
     public FfmpegEncoder Encoder;
     internal ILiveStreamSource StreamSource;

--- a/DesktopBuddy/Sessions/LinuxCursorEffectSuspender.cs
+++ b/DesktopBuddy/Sessions/LinuxCursorEffectSuspender.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DesktopBuddy;
+
+/// <summary>
+/// Suspends KWin's "shake cursor to find it" effect while any desktop is shared.
+///
+/// While a share is active there are two things driving one cursor: DesktopBuddy injecting
+/// absolute pointer motion at the laser's hit point, and the user's real mouse. The pointer
+/// snaps between the two positions many times a second, KWin reads that as shaking, and
+/// magnifies the cursor further the longer it continues.
+///
+/// The effect is unloaded at runtime rather than disabled in kwinrc, so a crash cannot leave
+/// the user's configuration modified — a KWin reconfigure or restart brings it back.
+/// Non-KDE desktops have no such effect and every call here is a harmless no-op.
+/// </summary>
+internal static class LinuxCursorEffectSuspender
+{
+    private const string EffectName = "shakecursor";
+
+    private static readonly object Lock = new();
+    private static bool _suspended;
+    private static bool _busy;
+
+    /// <summary>
+    /// Drives the effect from the live session count. Sessions are removed from
+    /// <c>ActiveSessions</c> in several places, so this is derived from the actual count on
+    /// every update rather than counted through hooks that a removal path could bypass.
+    /// Cheap and idempotent when nothing needs to change.
+    /// </summary>
+    internal static void Sync(int activeShareCount)
+    {
+        if (!DesktopBuddyPlatform.IsLinux) return;
+
+        bool wanted = activeShareCount > 0
+                      && (DesktopBuddyMod.Config?.GetValue(DesktopBuddyMod.LinuxSuspendShakeCursor) ?? true);
+
+        lock (Lock)
+        {
+            if (_busy || wanted == _suspended) return;
+            _busy = true;
+        }
+
+        // The D-Bus round trip is short but this runs from the update loop, so keep it off it.
+        Task.Run(() =>
+        {
+            try
+            {
+                if (wanted) Suspend();
+                else Restore();
+            }
+            finally { lock (Lock) { _busy = false; } }
+        });
+    }
+
+    /// <summary>Restores the effect unconditionally, for shutdown paths.</summary>
+    internal static void RestoreNow()
+    {
+        if (!DesktopBuddyPlatform.IsLinux) return;
+        lock (Lock) { if (!_suspended) return; }
+        Restore();
+    }
+
+    private static void Suspend()
+    {
+        try
+        {
+            using var bridge = new LinuxNativeBridge();
+            // Only touch the effect if it was actually on, so we never switch on something
+            // the user had deliberately turned off.
+            if (bridge.KWinEffectLoaded(EffectName) != 1) return;
+            if (!bridge.KWinEffectSet(EffectName, load: false)) return;
+
+            lock (Lock) _suspended = true;
+            DesktopBuddyMod.Msg("[CursorEffect] Suspended KWin shakecursor while sharing");
+        }
+        catch (Exception ex) { DesktopBuddyMod.Msg($"[CursorEffect] Suspend failed: {ex.Message}"); }
+    }
+
+    private static void Restore()
+    {
+        try
+        {
+            using var bridge = new LinuxNativeBridge();
+            if (bridge.KWinEffectSet(EffectName, load: true))
+                DesktopBuddyMod.Msg("[CursorEffect] Restored KWin shakecursor");
+        }
+        catch (Exception ex) { DesktopBuddyMod.Msg($"[CursorEffect] Restore failed: {ex.Message}"); }
+        finally { lock (Lock) _suspended = false; }
+    }
+}

--- a/DesktopBuddy/Sessions/Spawning/DesktopInputWiring.cs
+++ b/DesktopBuddy/Sessions/Spawning/DesktopInputWiring.cs
@@ -60,8 +60,14 @@ internal static class DesktopInputWiring
 
         void TargetLinuxInput()
         {
-            if (DesktopBuddyPlatform.IsLinux)
-                WindowInput.LinuxInputSession = session.LinuxInputSessionId;
+            if (!DesktopBuddyPlatform.IsLinux) return;
+            // Input goes to the shared workspace session, so the focused panel's captured
+            // region has to travel with it or clicks land on the wrong screen.
+            WindowInput.SetLinuxInputTarget(
+                session.LinuxInputSessionId,
+                session.LinuxPositionX, session.LinuxPositionY,
+                session.Streamer?.Width ?? 0, session.Streamer?.Height ?? 0,
+                session.LinuxWorkspaceWidth, session.LinuxWorkspaceHeight);
         }
 
         void SendDesktopPressed(Component source, float2 point)
@@ -72,6 +78,7 @@ internal static class DesktopInputWiring
             float u = point.x;
             float v = point.y;
             uint touchId = GetTouchId(source);
+
             session.ActiveTouchIds.Add(touchId);
             WindowInput.SendAtPointWhenTargetAcceptable(
                 hwnd,
@@ -89,6 +96,7 @@ internal static class DesktopInputWiring
             TargetLinuxInput();
             if (ShouldIgnoreDesktopInput()) return;
             uint touchId = GetTouchId(source);
+
             if (!session.ActiveTouchIds.Contains(touchId)) return;
             float u = point.x;
             float v = point.y;
@@ -110,6 +118,7 @@ internal static class DesktopInputWiring
             uint touchId = GetTouchId(source);
             float u = point.x;
             float v = point.y;
+
             if (!session.ActiveTouchIds.Remove(touchId)) return;
             WindowInput.SendAtPointWhenTargetAcceptable(
                 hwnd,
@@ -160,31 +169,71 @@ internal static class DesktopInputWiring
                     : null;
                 if (controller != null)
                 {
+                    // While the panel is pinned the grab action cannot move it, so it is free
+                    // to mean right-click instead. Digital.Pressed is already edge-triggered;
+                    // the tick guard only stops a second source firing within the same frame.
+                    if (session.PanelLocked && controller.ActionGrab.Pressed)
+                    {
+                        double grabTick = root.World.Time.WorldTime;
+                        if (grabTick != session.LastGrabTick)
+                        {
+                            session.LastGrabTick = grabTick;
+                            float ru = hu, rv = hv;
+                            ClaimSource(source);
+                            WindowInput.SendAtPointWhenTargetAcceptable(
+                                hwnd, ru, rv, streamer.Width, streamer.Height, streamer.MonitorHandle,
+                                () => WindowInput.SendRightClick(hwnd, ru, rv, streamer.Width, streamer.Height, streamer.MonitorHandle),
+                                "right click");
+                        }
+                    }
+
                     float axisY = controller.Axis.Value.y;
                     if (Math.Abs(axisY) > 0.15f)
                     {
                         double tick = root.World.Time.WorldTime;
-                        bool sameDir = session.LastScrollSign == 0 || Math.Sign(axisY) == session.LastScrollSign;
-                        if (tick != session.LastScrollTick && sameDir)
+                        if (tick != session.LastScrollTick)
                         {
                             session.LastScrollTick = tick;
-                            session.LastScrollSign = Math.Sign(axisY);
-                            ClaimSource(source);
-                            int wheelDelta = (int)(axisY * 120f);
-                            WindowInput.SendAtPointWhenTargetAcceptable(
-                                hwnd,
-                                hu,
-                                hv,
-                                streamer.Width,
-                                streamer.Height,
-                                streamer.MonitorHandle,
-                                () => WindowInput.SendScroll(hwnd, hu, hv, streamer.Width, streamer.Height, wheelDelta, streamer.MonitorHandle),
-                                "controller wheel");
+
+                            int sign = Math.Sign(axisY);
+                            if (sign != session.LastScrollSign)
+                            {
+                                // Reversing should respond at once rather than working off
+                                // whatever was banked in the old direction.
+                                session.LastScrollSign = sign;
+                                session.StickScrollAccum = 0f;
+                            }
+
+                            float speed = DesktopBuddyMod.Config?.GetValue(DesktopBuddyMod.StickScrollSpeed) ?? 8f;
+                            if (speed <= 0f) speed = 8f;
+
+                            // Bank notches against elapsed time, so the rate is in notches per
+                            // second rather than per frame. The old per-frame emit meant scroll
+                            // speed tracked framerate: ~90 notches a second at 90 FPS.
+                            session.StickScrollAccum += axisY * speed * (float)root.World.Time.Delta;
+
+                            while (Math.Abs(session.StickScrollAccum) >= 1f)
+                            {
+                                int step = Math.Sign(session.StickScrollAccum);
+                                session.StickScrollAccum -= step;
+                                int wheelDelta = step * 120;
+                                ClaimSource(source);
+                                WindowInput.SendAtPointWhenTargetAcceptable(
+                                    hwnd,
+                                    hu,
+                                    hv,
+                                    streamer.Width,
+                                    streamer.Height,
+                                    streamer.MonitorHandle,
+                                    () => WindowInput.SendScroll(hwnd, hu, hv, streamer.Width, streamer.Height, wheelDelta, streamer.MonitorHandle),
+                                    "controller wheel");
+                            }
                         }
                     }
                     else
                     {
                         session.LastScrollSign = 0;
+                        session.StickScrollAccum = 0f;
                     }
                 }
             }

--- a/DesktopBuddy/Sessions/Spawning/SessionSpawner.cs
+++ b/DesktopBuddy/Sessions/Spawning/SessionSpawner.cs
@@ -46,7 +46,11 @@ public partial class DesktopBuddyMod
             float userScale = GetUserSpawnScale(userRoot);
             root.LocalScale = float3.One * userScale;
             root.GlobalPosition = headPos + forward * (0.8f * userScale);
-            root.GlobalRotation = floatQ.LookRotation(forward, float3.Up);
+            // Face the user, then pitch about the panel's own right axis so the tilt is
+            // applied in panel space and stays correct whichever way the user is turned.
+            float spawnTilt = Config?.GetValue(SpawnTilt) ?? 0f;
+            spawnTilt = MathX.Clamp(spawnTilt, -85f, 85f);
+            root.GlobalRotation = floatQ.LookRotation(forward, float3.Up) * floatQ.Euler(spawnTilt, 0f, 0f);
             var destroyer = root.AttachComponent<DestroyOnUserLeave>();
 
             destroyer.TargetUser.Target = localUser;

--- a/DesktopBuddy/Sessions/Spawning/SessionSpawner.cs
+++ b/DesktopBuddy/Sessions/Spawning/SessionSpawner.cs
@@ -251,6 +251,11 @@ public partial class DesktopBuddyMod
         {
             Streamer = streamer,
             LinuxInputSessionId = streamer.LinuxInputSessionId,
+            LinuxCaptureSessionId = streamer.LinuxCaptureSessionId,
+            LinuxPositionX = streamer.LinuxPositionX,
+            LinuxPositionY = streamer.LinuxPositionY,
+            LinuxWorkspaceWidth = streamer.LinuxWorkspaceWidth,
+            LinuxWorkspaceHeight = streamer.LinuxWorkspaceHeight,
             Texture = procTex,
             Canvas = ui.Canvas,
             Root = root,
@@ -271,6 +276,7 @@ public partial class DesktopBuddyMod
         };
         ActiveSessions.Add(session);
         LinuxCursorEffectSuspender.Sync(ActiveSessions.Count);
+        LinuxSessionLifetime.Sync(ActiveSessions.Count);
         root.Destroyed += _ => CleanupAndRemoveSession(session, "root destroyed");
         if (Config?.GetValue(DynamicLightsEnabled) ?? false)
             CreateAdaptiveScreenLight(root, session, hwnd, streamer.MonitorHandle);
@@ -590,6 +596,7 @@ public partial class DesktopBuddyMod
 
         var kbBtn = ep.Button("⌨️"); StyleButton(kbBtn);
         var anchorBtn = ep.Button("⚓");   StyleButton(anchorBtn);
+        var lockBtn = ep.Button("📌"); StyleButton(lockBtn);
         var privateBtn = ep.Button("🔒"); StyleButton(privateBtn);
 
         ep.Style.MinWidth = 1f;
@@ -895,6 +902,7 @@ public partial class DesktopBuddyMod
                    (previewBtn != null && !previewBtn.IsDestroyed && previewBtn.IsHovering.Value) ||
                    (kbBtn != null && !kbBtn.IsDestroyed && kbBtn.IsHovering.Value) ||
                    (anchorBtn != null && !anchorBtn.IsDestroyed && anchorBtn.IsHovering.Value) ||
+                   (lockBtn != null && !lockBtn.IsDestroyed && lockBtn.IsHovering.Value) ||
                    (privateBtn != null && !privateBtn.IsDestroyed && privateBtn.IsHovering.Value) ||
                    (resyncBtn != null && !resyncBtn.IsDestroyed && resyncBtn.IsHovering.Value) ||
                    (curveSlider != null && !curveSlider.IsDestroyed && curveSlider.IsHovering.Value) ||
@@ -969,6 +977,7 @@ public partial class DesktopBuddyMod
         TrackHover(previewBtn);
         TrackHover(kbBtn);
         TrackHover(anchorBtn);
+        TrackHover(lockBtn);
         TrackHover(privateBtn);
         TrackHover(resyncBtn);
         root.World.RunInUpdates(4, PollSharedBarHover);
@@ -1113,6 +1122,18 @@ public partial class DesktopBuddyMod
             }
             var img = anchorBtn.Slot.GetComponent<Image>();
             if (img != null) img.Tint.Value = isAnchored ? anchorActiveColor : colorX.Clear;
+        };
+
+        lockBtn.LocalPressed += (IButton b, ButtonEventData d) =>
+        {
+            if (session == null) return;
+            session.PanelLocked = !session.PanelLocked;
+            if (grabbable != null && !grabbable.IsDestroyed)
+                grabbable.Enabled = !session.PanelLocked;
+            session.LastGrabTick = 0;
+            Msg($"[Lock] Panel {(session.PanelLocked ? "pinned (grab acts as right-click)" : "unpinned")}");
+            var lockImg = lockBtn.Slot.GetComponent<Image>();
+            if (lockImg != null) lockImg.Tint.Value = session.PanelLocked ? anchorActiveColor : colorX.Clear;
         };
 
         deviceIndicatorsSlot = CreateVirtualDeviceControls(

--- a/DesktopBuddy/Sessions/Spawning/SessionSpawner.cs
+++ b/DesktopBuddy/Sessions/Spawning/SessionSpawner.cs
@@ -270,6 +270,7 @@ public partial class DesktopBuddyMod
             SeenRelatedHwnds = seenRelatedHwnds,
         };
         ActiveSessions.Add(session);
+        LinuxCursorEffectSuspender.Sync(ActiveSessions.Count);
         root.Destroyed += _ => CleanupAndRemoveSession(session, "root destroyed");
         if (Config?.GetValue(DynamicLightsEnabled) ?? false)
             CreateAdaptiveScreenLight(root, session, hwnd, streamer.MonitorHandle);

--- a/DesktopBuddy/Sessions/Update/SessionCleanup.cs
+++ b/DesktopBuddy/Sessions/Update/SessionCleanup.cs
@@ -22,20 +22,26 @@ public partial class DesktopBuddyMod
 
         if (session.LinuxInputSessionId != 0)
         {
-            try
-            {
-                using var inputBridge = new LinuxNativeBridge();
-                int stopStatus = inputBridge.InputStop(session.LinuxInputSessionId);
-                if (stopStatus == 0)
-                    Msg($"[Cleanup] Stopped Linux input session {session.LinuxInputSessionId} (portal session closed)");
-                else
-                    Msg($"[Cleanup] Linux input session {session.LinuxInputSessionId} stop returned {stopStatus} " +
-                        $"(portal session may still be open): {inputBridge.GetInputLastError() ?? "(no error)"}");
-            }
-            catch (Exception ex) { Msg($"[Cleanup] Linux input stop error: {ex.Message}"); }
+            // The input session is shared by every panel, so it must NOT be stopped here.
+            // Closing one panel would otherwise kill input for all the others. Releasing it
+            // is LinuxSessionLifetime's job, once no panels remain.
             if (WindowInput.LinuxInputSession == session.LinuxInputSessionId)
                 WindowInput.LinuxInputSession = 0;
             session.LinuxInputSessionId = 0;
+        }
+
+        if (session.LinuxCaptureSessionId != 0)
+        {
+            try
+            {
+                using var captureBridge = new LinuxNativeBridge();
+                int status = captureBridge.ScreencastStop(session.LinuxCaptureSessionId);
+                Msg(status == 0
+                    ? $"[Cleanup] Stopped Linux capture session {session.LinuxCaptureSessionId}"
+                    : $"[Cleanup] Linux capture session {session.LinuxCaptureSessionId} stop returned {status}: {captureBridge.GetInputLastError() ?? "(no error)"}");
+            }
+            catch (Exception ex) { Msg($"[Cleanup] Linux capture stop error: {ex.Message}"); }
+            session.LinuxCaptureSessionId = 0;
         }
 
         if (VMic != null && session.VMicListener != null)
@@ -264,6 +270,7 @@ public partial class DesktopBuddyMod
 
         ActiveSessions.Remove(session);
         LinuxCursorEffectSuspender.Sync(ActiveSessions.Count);
+        LinuxSessionLifetime.Sync(ActiveSessions.Count);
     }
 
 }

--- a/DesktopBuddy/Sessions/Update/SessionCleanup.cs
+++ b/DesktopBuddy/Sessions/Update/SessionCleanup.cs
@@ -263,6 +263,7 @@ public partial class DesktopBuddyMod
             CleanupSession(session);
 
         ActiveSessions.Remove(session);
+        LinuxCursorEffectSuspender.Sync(ActiveSessions.Count);
     }
 
 }

--- a/DesktopBuddy/Sessions/Update/SessionCleanup.cs
+++ b/DesktopBuddy/Sessions/Update/SessionCleanup.cs
@@ -25,8 +25,12 @@ public partial class DesktopBuddyMod
             try
             {
                 using var inputBridge = new LinuxNativeBridge();
-                inputBridge.InputStop(session.LinuxInputSessionId);
-                Msg($"[Cleanup] Stopped Linux input session {session.LinuxInputSessionId}");
+                int stopStatus = inputBridge.InputStop(session.LinuxInputSessionId);
+                if (stopStatus == 0)
+                    Msg($"[Cleanup] Stopped Linux input session {session.LinuxInputSessionId} (portal session closed)");
+                else
+                    Msg($"[Cleanup] Linux input session {session.LinuxInputSessionId} stop returned {stopStatus} " +
+                        $"(portal session may still be open): {inputBridge.GetInputLastError() ?? "(no error)"}");
             }
             catch (Exception ex) { Msg($"[Cleanup] Linux input stop error: {ex.Message}"); }
             if (WindowInput.LinuxInputSession == session.LinuxInputSessionId)

--- a/DesktopBuddy/Sessions/Update/SessionUpdateLoop.cs
+++ b/DesktopBuddy/Sessions/Update/SessionUpdateLoop.cs
@@ -30,6 +30,7 @@ public partial class DesktopBuddyMod
                 }
             }
             LinuxCursorEffectSuspender.Sync(ActiveSessions.Count);
+        LinuxSessionLifetime.Sync(ActiveSessions.Count);
             _scheduledWorlds.Remove(world);
             return;
         }
@@ -48,6 +49,7 @@ public partial class DesktopBuddyMod
                 {
                     ActiveSessions.RemoveAt(i);
                     LinuxCursorEffectSuspender.Sync(ActiveSessions.Count);
+        LinuxSessionLifetime.Sync(ActiveSessions.Count);
                     continue;
                 }
 

--- a/DesktopBuddy/Sessions/Update/SessionUpdateLoop.cs
+++ b/DesktopBuddy/Sessions/Update/SessionUpdateLoop.cs
@@ -29,6 +29,7 @@ public partial class DesktopBuddyMod
                     ActiveSessions.RemoveAt(i);
                 }
             }
+            LinuxCursorEffectSuspender.Sync(ActiveSessions.Count);
             _scheduledWorlds.Remove(world);
             return;
         }
@@ -46,6 +47,7 @@ public partial class DesktopBuddyMod
                 if (session.Cleaned)
                 {
                     ActiveSessions.RemoveAt(i);
+                    LinuxCursorEffectSuspender.Sync(ActiveSessions.Count);
                     continue;
                 }
 

--- a/DesktopBuddy/UI/ContextMenuPatch.cs
+++ b/DesktopBuddy/UI/ContextMenuPatch.cs
@@ -436,6 +436,15 @@ public static class ContextMenuPatch
                 {
                     string err = bridge.GetInputLastError();
                     DesktopBuddyMod.Msg($"[ContextMenu] Linux portal session failed inputSession={inputSession} node={selection.NodeId} error={err ?? "(none)"}");
+
+                    // A restore token that no longer resolves stays broken forever, so drop it
+                    // and fall back to the picker instead of leaving a dead entry on the dial.
+                    if (reshare != null)
+                    {
+                        ForgetLinuxSource(reshare);
+                        DesktopBuddyMod.Msg("[ContextMenu] Dropped stale saved Linux source; reopening portal picker");
+                        OpenLinuxPortalPickerThenSpawn(world, null);
+                    }
                     return;
                 }
 
@@ -454,6 +463,14 @@ public static class ContextMenuPatch
                 DesktopBuddyMod.Msg($"[ContextMenu] Linux portal picker error: {ex}");
             }
         });
+    }
+
+    private static void ForgetLinuxSource(LinuxSharedSource source)
+    {
+        if (source == null) return;
+        lock (_linuxSourcesLock)
+            _linuxSources.Remove(source);
+        SaveLinuxSources();
     }
 
     private static string RememberLinuxSource(LinuxSharedSource existing, string token, bool isMonitor, int width, int height)

--- a/DesktopBuddy/UI/ContextMenuPatch.cs
+++ b/DesktopBuddy/UI/ContextMenuPatch.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using HarmonyLib;
 using FrooxEngine;
@@ -528,19 +529,34 @@ public static class ContextMenuPatch
                 // Capture is a separate ScreenCast session so the picker offers each monitor
                 // individually instead of one whole-workspace entry.
                 ulong captureSession = bridge.ScreencastStart(tokenIn, out var selection, out var newToken, out var isMonitor);
+
+                // A restore token that no longer resolves stays broken forever, so drop it and
+                // fall back to the picker instead of leaving a dead entry on the dial.
+                void DropStaleSourceAndReopenPicker()
+                {
+                    if (reshare == null) return;
+                    ForgetLinuxSource(reshare);
+                    DesktopBuddyMod.Msg("[ContextMenu] Dropped stale saved Linux source; reopening portal picker");
+                    OpenLinuxPortalPickerThenSpawn(world, null);
+                }
+
                 if (captureSession == 0 || selection.NodeId == 0)
                 {
                     string err = bridge.GetInputLastError();
                     DesktopBuddyMod.Msg($"[ContextMenu] Linux capture session failed captureSession={captureSession} node={selection.NodeId} error={err ?? "(none)"}");
+                    DropStaleSourceAndReopenPicker();
+                    return;
+                }
 
-                    // A restore token that no longer resolves stays broken forever, so drop it
-                    // and fall back to the picker instead of leaving a dead entry on the dial.
-                    if (reshare != null)
-                    {
-                        ForgetLinuxSource(reshare);
-                        DesktopBuddyMod.Msg("[ContextMenu] Dropped stale saved Linux source; reopening portal picker");
-                        OpenLinuxPortalPickerThenSpawn(world, null);
-                    }
+                // A stale token can also resolve to a session and still hand back a node that is
+                // already gone. That case used to reach the renderer, which faults inside PipeWire
+                // with no managed exception to catch and takes the session down with it, so the
+                // node is confirmed here while falling back to the picker is still possible.
+                if (!WaitForNode(bridge, selection.NodeId))
+                {
+                    DesktopBuddyMod.Msg($"[ContextMenu] Linux capture node={selection.NodeId} never appeared in PipeWire; treating source as stale");
+                    bridge.ScreencastStop(captureSession);
+                    DropStaleSourceAndReopenPicker();
                     return;
                 }
 
@@ -563,6 +579,24 @@ public static class ContextMenuPatch
                 DesktopBuddyMod.Msg($"[ContextMenu] Linux portal picker error: {ex}");
             }
         });
+    }
+
+    /// <summary>
+    /// Confirms a PipeWire node is live, tolerating the short gap between the portal handing back
+    /// a session and its stream node reaching the registry. A single miss is not evidence of a
+    /// dead source; only a node still absent at the end of the window is treated as one.
+    /// </summary>
+    private static bool WaitForNode(LinuxNativeBridge bridge, uint nodeId)
+    {
+        const int Attempts = 10;
+        const int DelayMs = 50;
+
+        for (int attempt = 0; attempt < Attempts; attempt++)
+        {
+            if (bridge.NodeExists(nodeId)) return true;
+            Thread.Sleep(DelayMs);
+        }
+        return false;
     }
 
     private static void ForgetLinuxSource(LinuxSharedSource source)

--- a/DesktopBuddy/UI/ContextMenuPatch.cs
+++ b/DesktopBuddy/UI/ContextMenuPatch.cs
@@ -274,6 +274,13 @@ public static class ContextMenuPatch
         public string Label;
         public string RestoreToken;
         public bool IsMonitor;
+        /// <summary>
+        /// Position of the monitor in compositor coordinates. Two monitors of the same size
+        /// are indistinguishable by label alone, so this is what gives each saved screen its
+        /// own identity rather than collapsing them into one entry.
+        /// </summary>
+        public int PositionX;
+        public int PositionY;
     }
 
     private static readonly object _linuxSourcesLock = new();
@@ -296,6 +303,7 @@ public static class ContextMenuPatch
         {
             string serialized = DesktopBuddyMod.Config?.GetValue(DesktopBuddyMod.LinuxSharedSources);
             if (string.IsNullOrWhiteSpace(serialized)) return;
+            var legacyTokens = new List<string>();
             lock (_linuxSourcesLock)
             {
                 _linuxSources.Clear();
@@ -306,15 +314,47 @@ public static class ContextMenuPatch
                     if (parts.Length < 3) continue;
                     string token = UnB64(parts[2]);
                     if (string.IsNullOrEmpty(token)) continue;
+
+                    // Entries written before per-screen support hold a RemoteDesktop token,
+                    // which a ScreenCast session cannot restore: the portal ignores it and
+                    // shows the picker instead, so the dial entry silently stops meaning
+                    // anything. Drop those and revoke the grant they left behind. The extra
+                    // position fields are what distinguishes the new format.
+                    if (parts.Length < 5)
+                    {
+                        legacyTokens.Add(token);
+                        continue;
+                    }
+
+                    int px = int.TryParse(parts[3], out int parsedX) ? parsedX : 0;
+                    int py = int.TryParse(parts[4], out int parsedY) ? parsedY : 0;
                     _linuxSources.Add(new LinuxSharedSource
                     {
                         IsMonitor = parts[0] == "1",
                         Label = UnB64(parts[1]),
                         RestoreToken = token,
+                        PositionX = px,
+                        PositionY = py,
                     });
                 }
             }
             DesktopBuddyMod.Msg($"[ContextMenu] Loaded {_linuxSources.Count} saved Linux source(s)");
+
+            if (legacyTokens.Count > 0)
+            {
+                DesktopBuddyMod.Msg($"[ContextMenu] Dropped {legacyTokens.Count} saved source(s) from the pre-per-screen format");
+                SaveLinuxSources();
+                Task.Run(() =>
+                {
+                    try
+                    {
+                        using var bridge = new LinuxNativeBridge();
+                        foreach (string legacy in legacyTokens)
+                            bridge.PortalRevokeToken("remote-desktop", legacy);
+                    }
+                    catch (Exception ex) { DesktopBuddyMod.Msg($"[ContextMenu] Legacy revoke error: {ex.Message}"); }
+                });
+            }
         }
         catch (Exception ex) { DesktopBuddyMod.Msg($"[ContextMenu] Load sources error: {ex.Message}"); }
     }
@@ -331,7 +371,9 @@ public static class ContextMenuPatch
                     if (sb.Length > 0) sb.Append('\n');
                     sb.Append(s.IsMonitor ? '1' : '0').Append('|')
                       .Append(B64(s.Label)).Append('|')
-                      .Append(B64(s.RestoreToken));
+                      .Append(B64(s.RestoreToken)).Append('|')
+                      .Append(s.PositionX).Append('|')
+                      .Append(s.PositionY);
                 }
             }
             DesktopBuddyMod.Config?.Set(DesktopBuddyMod.LinuxSharedSources, sb.ToString());
@@ -418,6 +460,53 @@ public static class ContextMenuPatch
                 OpenLinuxPortalPickerThenSpawn(menu.World, captured);
             };
         }
+
+        if (sources.Count == 0)
+            return;
+
+        LocaleString clearLabel = "Clear saved screens";
+        colorX? clearColor = new colorX(0.45f, 0.15f, 0.15f, 1f);
+        var clear = menu.AddItem(in clearLabel, (Uri)null!, in clearColor);
+        clear.Button.LocalPressed += (IButton b, ButtonEventData d) =>
+        {
+            ClearLinuxSources();
+            // Redraw in place rather than closing, so the list is visibly empty.
+            ShowLinuxPickerPage(menu);
+        };
+    }
+
+    /// <summary>
+    /// Forgets every saved source and revokes the portal grants behind them, so clearing the
+    /// list also stops those grants lingering in the desktop's remembered permissions.
+    /// </summary>
+    private static void ClearLinuxSources()
+    {
+        List<string> tokens;
+        lock (_linuxSourcesLock)
+        {
+            tokens = new List<string>();
+            foreach (var s in _linuxSources)
+                if (!string.IsNullOrEmpty(s.RestoreToken)) tokens.Add(s.RestoreToken);
+            _linuxSources.Clear();
+        }
+
+        SaveLinuxSources();
+        DesktopBuddyMod.Msg($"[ContextMenu] Cleared {tokens.Count} saved Linux source(s)");
+
+        if (tokens.Count == 0) return;
+
+        Task.Run(() =>
+        {
+            try
+            {
+                using var bridge = new LinuxNativeBridge();
+                int revoked = 0;
+                foreach (string token in tokens)
+                    if (bridge.PortalRevokeToken("screencast", token)) revoked++;
+                DesktopBuddyMod.Msg($"[ContextMenu] Revoked {revoked}/{tokens.Count} cleared portal grant(s)");
+            }
+            catch (Exception ex) { DesktopBuddyMod.Msg($"[ContextMenu] Clear revoke error: {ex.Message}"); }
+        });
     }
 
     private static void OpenLinuxPortalPickerThenSpawn(World world, LinuxSharedSource reshare)
@@ -431,11 +520,18 @@ public static class ContextMenuPatch
             try
             {
                 using var bridge = new LinuxNativeBridge();
-                ulong inputSession = bridge.SessionStart(tokenIn, out var selection, out var newToken, out var isMonitor);
-                if (inputSession == 0 || selection.NodeId == 0)
+
+                // Input first: one shared RemoteDesktop session serves every panel, and it is
+                // what makes absolute pointer injection possible at all.
+                ulong inputSession = LinuxInputSessionManager.Ensure(out int workspaceW, out int workspaceH);
+
+                // Capture is a separate ScreenCast session so the picker offers each monitor
+                // individually instead of one whole-workspace entry.
+                ulong captureSession = bridge.ScreencastStart(tokenIn, out var selection, out var newToken, out var isMonitor);
+                if (captureSession == 0 || selection.NodeId == 0)
                 {
                     string err = bridge.GetInputLastError();
-                    DesktopBuddyMod.Msg($"[ContextMenu] Linux portal session failed inputSession={inputSession} node={selection.NodeId} error={err ?? "(none)"}");
+                    DesktopBuddyMod.Msg($"[ContextMenu] Linux capture session failed captureSession={captureSession} node={selection.NodeId} error={err ?? "(none)"}");
 
                     // A restore token that no longer resolves stays broken forever, so drop it
                     // and fall back to the picker instead of leaving a dead entry on the dial.
@@ -451,11 +547,15 @@ public static class ContextMenuPatch
                 int width = selection.Width > 0 ? checked((int)selection.Width) : 1280;
                 int height = selection.Height > 0 ? checked((int)selection.Height) : 720;
 
-                DesktopBuddyMod.Msg($"[ContextMenu] Linux combined session={inputSession} node={selection.NodeId} (capture + input share one portal session)");
+                DesktopBuddyMod.Msg($"[ContextMenu] Linux capture session={captureSession} input session={inputSession} node={selection.NodeId}");
 
-                string title = RememberLinuxSource(reshare, newToken, isMonitor, width, height);
-                LinuxPortalSelectionStore.Set(new LinuxPortalSelection(selection.NodeId, width, height, inputSession));
-                DesktopBuddyMod.Msg($"[ContextMenu] Linux portal selected node={selection.NodeId} size={width}x{height} monitor={isMonitor} token={(newToken != null ? "yes" : "no")}");
+                string title = RememberLinuxSource(reshare, newToken, isMonitor, width, height,
+                    selection.PositionX, selection.PositionY);
+                LinuxPortalSelectionStore.Set(new LinuxPortalSelection(
+                    selection.NodeId, width, height, inputSession, captureSession,
+                    selection.PositionX, selection.PositionY, workspaceW, workspaceH));
+                DesktopBuddyMod.Msg($"[ContextMenu] Linux portal selected node={selection.NodeId} size={width}x{height} " +
+                    $"pos=({selection.PositionX},{selection.PositionY}) workspace={workspaceW}x{workspaceH} monitor={isMonitor} token={(newToken != null ? "yes" : "no")}");
                 world.RunInUpdates(0, () => DesktopBuddyMod.SpawnStreaming(world, IntPtr.Zero, title, startPrivate: DesktopBuddyMod.Config?.GetValue(DesktopBuddyMod.NewWindowsStartPrivate) ?? false));
             }
             catch (Exception ex)
@@ -488,15 +588,45 @@ public static class ContextMenuPatch
         try
         {
             using var bridge = new LinuxNativeBridge();
-            if (bridge.InputRevokeToken(token))
+            // Saved sources are ScreenCast grants now that capture has its own session, so
+            // they live in the "screencast" table rather than "remote-desktop".
+            if (bridge.PortalRevokeToken("screencast", token))
                 DesktopBuddyMod.Msg("[ContextMenu] Revoked superseded Linux portal grant");
         }
         catch (Exception ex) { DesktopBuddyMod.Msg($"[ContextMenu] Revoke token error: {ex.Message}"); }
     }
 
-    private static string RememberLinuxSource(LinuxSharedSource existing, string token, bool isMonitor, int width, int height)
+    /// <summary>
+    /// Builds the dial label for a captured source. Screens are commonly identical in size,
+    /// so dimensions alone cannot tell two of them apart; the compositor-space position is the
+    /// only stable discriminator the portal gives us, and it is appended once more than one
+    /// screen is in play.
+    /// </summary>
+    private static string BuildLinuxSourceLabel(bool isMonitor, int width, int height, int posX, int posY)
     {
-        string label = isMonitor ? $"Desktop ({width}×{height})" : $"Window ({width}×{height})";
+        if (!isMonitor)
+            return $"Window ({width}×{height})";
+
+        // Prefer the compositor's connector name; fall back to position, which is the only
+        // other thing that tells two identically sized screens apart.
+        string name = null;
+        try
+        {
+            using var bridge = new LinuxNativeBridge();
+            name = bridge.KWinOutputName(posX, posY, width, height);
+        }
+        catch (Exception ex) { DesktopBuddyMod.Msg($"[ContextMenu] Output name lookup failed: {ex.Message}"); }
+
+        if (!string.IsNullOrEmpty(name))
+            return $"Screen ({name}; {width}×{height}) @ {posX},{posY}";
+
+        return $"Screen ({width}×{height}) @ {posX},{posY}";
+    }
+
+    private static string RememberLinuxSource(LinuxSharedSource existing, string token, bool isMonitor,
+        int width, int height, int posX = 0, int posY = 0)
+    {
+        string label = BuildLinuxSourceLabel(isMonitor, width, height, posX, posY);
 
         if (string.IsNullOrEmpty(token))
             return existing?.Label ?? label;
@@ -508,8 +638,13 @@ public static class ContextMenuPatch
             entry = (existing != null && _linuxSources.Contains(existing)) ? existing : null;
             if (entry == null)
             {
+                // Match on the source's actual identity, not its label. Two 1920x1200 screens
+                // share a label under the old scheme and would collapse into one entry,
+                // revoking each other's grant.
                 foreach (var s in _linuxSources)
-                    if (s.RestoreToken == token || (s.Label == label && s.IsMonitor == isMonitor)) { entry = s; break; }
+                    if (s.RestoreToken == token ||
+                        (s.IsMonitor == isMonitor && s.PositionX == posX && s.PositionY == posY && s.Label == label))
+                    { entry = s; break; }
             }
 
             if (entry != null)
@@ -521,10 +656,19 @@ public static class ContextMenuPatch
                 entry.RestoreToken = token;
                 entry.Label = label;
                 entry.IsMonitor = isMonitor;
+                entry.PositionX = posX;
+                entry.PositionY = posY;
             }
             else
             {
-                entry = new LinuxSharedSource { Label = label, RestoreToken = token, IsMonitor = isMonitor };
+                entry = new LinuxSharedSource
+                {
+                    Label = label,
+                    RestoreToken = token,
+                    IsMonitor = isMonitor,
+                    PositionX = posX,
+                    PositionY = posY,
+                };
                 _linuxSources.Add(entry);
             }
         }

--- a/DesktopBuddy/UI/ContextMenuPatch.cs
+++ b/DesktopBuddy/UI/ContextMenuPatch.cs
@@ -468,9 +468,30 @@ public static class ContextMenuPatch
     private static void ForgetLinuxSource(LinuxSharedSource source)
     {
         if (source == null) return;
+        string token;
         lock (_linuxSourcesLock)
+        {
+            token = source.RestoreToken;
             _linuxSources.Remove(source);
+        }
         SaveLinuxSources();
+        RevokeLinuxToken(token);
+    }
+
+    /// <summary>
+    /// Drops a portal grant we no longer reference. Without this the grant persists in the
+    /// desktop's remembered-permissions list indefinitely, one entry per share.
+    /// </summary>
+    private static void RevokeLinuxToken(string token)
+    {
+        if (string.IsNullOrEmpty(token)) return;
+        try
+        {
+            using var bridge = new LinuxNativeBridge();
+            if (bridge.InputRevokeToken(token))
+                DesktopBuddyMod.Msg("[ContextMenu] Revoked superseded Linux portal grant");
+        }
+        catch (Exception ex) { DesktopBuddyMod.Msg($"[ContextMenu] Revoke token error: {ex.Message}"); }
     }
 
     private static string RememberLinuxSource(LinuxSharedSource existing, string token, bool isMonitor, int width, int height)
@@ -481,6 +502,7 @@ public static class ContextMenuPatch
             return existing?.Label ?? label;
 
         LinuxSharedSource entry;
+        string supersededToken = null;
         lock (_linuxSourcesLock)
         {
             entry = (existing != null && _linuxSources.Contains(existing)) ? existing : null;
@@ -492,6 +514,10 @@ public static class ContextMenuPatch
 
             if (entry != null)
             {
+                // The portal mints a fresh grant per start, so the token we are replacing is
+                // now unreferenced and has to be revoked rather than simply overwritten.
+                if (!string.IsNullOrEmpty(entry.RestoreToken) && entry.RestoreToken != token)
+                    supersededToken = entry.RestoreToken;
                 entry.RestoreToken = token;
                 entry.Label = label;
                 entry.IsMonitor = isMonitor;
@@ -504,6 +530,7 @@ public static class ContextMenuPatch
         }
 
         SaveLinuxSources();
+        RevokeLinuxToken(supersededToken);
 
         return label;
     }

--- a/DesktopBuddy/UI/Settings/SettingsPanel.StreamTab.cs
+++ b/DesktopBuddy/UI/Settings/SettingsPanel.StreamTab.cs
@@ -64,6 +64,10 @@ public partial class DesktopBuddyMod
                 RequestStreamEncoderRestart(session, "encoder preference");
             });
 
+        // Preferred GPU is selected by DXGI adapter LUID, which only exists on Windows.
+        if (DesktopBuddyPlatform.IsLinux)
+            return;
+
         string currentLuid = Config?.GetValue(PreferredGpuLuid)?.Trim() ?? "";
         var gpus = WgcCapture.EnumerateAdapters()
             .Where(g => !g.IsBasicRenderDriver && !string.IsNullOrWhiteSpace(g.Name))

--- a/DesktopBuddyLinuxBridge/desktopbuddy_linux_bridge.c
+++ b/DesktopBuddyLinuxBridge/desktopbuddy_linux_bridge.c
@@ -114,6 +114,7 @@ enum {
   OP_START_NODE = 6,
   OP_COPY_FRAME = 7,
   OP_CLOSE_FRAME = 8,
+  OP_LOAD = 9,
 };
 
 typedef int32_t (*db_linux_capture_start_node_fn)(uint32_t node_id, uint64_t *capture_id);
@@ -177,6 +178,16 @@ int32_t DesktopBuddyLinuxBridgeCall(DbLinuxBridgeCall *call) {
   if (status != 0) {
     call->status = status;
     return status;
+  }
+
+  /* Loading the Rust library drags PipeWire and its dependencies into the Wine process, which
+     is as capable of faulting as the capture connect that follows it. Every op loads lazily,
+     so a crash on the first call could be either one. Exposing the load on its own lets the
+     caller record a survived dlopen before it attempts a connect, which narrows a dead
+     renderer down to a single stage. */
+  if (call->op == OP_LOAD) {
+    call->status = 0;
+    return 0;
   }
 
   if (call->op == OP_POLL) {

--- a/DesktopBuddyLinuxNative/src/lib.rs
+++ b/DesktopBuddyLinuxNative/src/lib.rs
@@ -10,6 +10,7 @@ use pipewire as pw;
 use wlx_capture::WlxCapture;
 
 mod audio;
+mod portal_capture;
 mod portal_input;
 use wlx_capture::frame::{MemFdFrame, WlxFrame};
 use wlx_capture::pipewire::PipewireCapture;
@@ -35,6 +36,11 @@ pub struct DbLinuxSelection {
     pub is_monitor: u32,
     pub restore_token_len: u32,
     pub restore_token: [u8; 256],
+    /// Offset of the captured source within the compositor's coordinate space. Needed to map
+    /// panel-local input onto the workspace when capture and input come from separate
+    /// sessions. Appended after the existing fields so the older layout stays aligned.
+    pub position_x: i32,
+    pub position_y: i32,
 }
 
 impl Default for DbLinuxSelection {
@@ -46,6 +52,8 @@ impl Default for DbLinuxSelection {
             is_monitor: 0,
             restore_token_len: 0,
             restore_token: [0; 256],
+            position_x: 0,
+            position_y: 0,
         }
     }
 }

--- a/DesktopBuddyLinuxNative/src/lib.rs
+++ b/DesktopBuddyLinuxNative/src/lib.rs
@@ -58,6 +58,29 @@ impl Default for DbLinuxSelection {
     }
 }
 
+/// Returned when an FFI entry point panicked and [`guard_ffi`] caught it.
+pub const DB_LINUX_PANICKED: i32 = -50;
+
+/// Runs an FFI entry point so a panic becomes a status code instead of an abort.
+///
+/// A panic cannot cross an `extern "C"` boundary: Rust aborts the process instead. Here that
+/// process is the Wine renderer, so an abort kills it mid-frame with no managed exception, no
+/// status code, and nothing in the log past the call that went in. Catching keeps the renderer
+/// alive and lets the C# side report the failure through its normal channels.
+///
+/// The closure state is built fresh per call, and the one piece of shared state a panic could
+/// leave inconsistent is the `captures()` mutex — whose callers already treat a poisoned lock
+/// as a plain failure — so asserting unwind safety costs nothing real here.
+fn guard_ffi<F: FnOnce() -> i32>(what: &str, body: F) -> i32 {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)) {
+        Ok(status) => status,
+        Err(_) => {
+            log::error!("{what} panicked; returning {DB_LINUX_PANICKED} instead of aborting");
+            DB_LINUX_PANICKED
+        }
+    }
+}
+
 struct CaptureRuntime {
     stop: Arc<AtomicBool>,
     latest: Arc<Mutex<Option<DbLinuxFrame>>>,
@@ -242,6 +265,12 @@ fn handle_frame(state: &CallbackState, frame: WlxFrame) -> Option<()> {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn db_linux_capture_start_node(node_id: u32, out_capture_id: *mut u64) -> i32 {
+    guard_ffi("db_linux_capture_start_node", || {
+        start_capture_node(node_id, out_capture_id)
+    })
+}
+
+fn start_capture_node(node_id: u32, out_capture_id: *mut u64) -> i32 {
     if node_id == 0 {
         return -12;
     }

--- a/DesktopBuddyLinuxNative/src/lib.rs
+++ b/DesktopBuddyLinuxNative/src/lib.rs
@@ -137,6 +137,92 @@ fn run_node_monitor(
     Ok(())
 }
 
+/// How long to wait for the server to answer the registry sync before giving up on the answer.
+const NODE_CHECK_TIMEOUT: Duration = Duration::from_millis(1500);
+
+/// Asks PipeWire whether `node_id` is currently a live node.
+///
+/// `Ok(None)` means the server did not answer in time — "could not tell", which is not the same
+/// as "absent" and must not be reported as one.
+fn node_exists(node_id: u32) -> Result<Option<bool>, pw::Error> {
+    pw::init();
+
+    let mainloop = pw::main_loop::MainLoopRc::new(None)?;
+    let context = pw::context::ContextRc::new(&mainloop, None)?;
+    let core = context.connect_rc(None)?;
+    let registry = core.get_registry_rc()?;
+
+    let found = Arc::new(AtomicBool::new(false));
+    let global_found = found.clone();
+    let _reg_listener = registry
+        .add_listener_local()
+        .global(move |global| {
+            if global.id == node_id && global.type_ == pw::types::ObjectType::Node {
+                global_found.store(true, Ordering::Release);
+            }
+        })
+        .register();
+
+    // The server replays every existing global before it answers a sync, so once `done` comes
+    // back for this one, a node we have not been told about is a node that does not exist.
+    let synced = Arc::new(AtomicBool::new(false));
+    let pending = core.sync(0)?;
+    let sync_done = synced.clone();
+    let sync_quit = mainloop.clone();
+    let _core_listener = core
+        .add_listener_local()
+        .done(move |id, seq| {
+            if id == pw::core::PW_ID_CORE && seq == pending {
+                sync_done.store(true, Ordering::Release);
+                sync_quit.quit();
+            }
+        })
+        .register();
+
+    // A wedged server must not turn sharing into a hang, so the loop always has an exit.
+    let timeout_quit = mainloop.clone();
+    let timer = mainloop.loop_().add_timer(move |_| timeout_quit.quit());
+    if let Err(e) = timer.update_timer(Some(NODE_CHECK_TIMEOUT), None).into_result() {
+        log::warn!("node check timer not armed ({e:?}); relying on the server to answer");
+    }
+
+    mainloop.run();
+
+    Ok(if synced.load(Ordering::Acquire) {
+        Some(found.load(Ordering::Acquire))
+    } else {
+        None
+    })
+}
+
+/// Reports whether a PipeWire node id is currently present: 1 present, 0 absent, -1 unknown.
+///
+/// A ScreenCast restore token that has gone stale can still resolve to a session and hand back a
+/// node id that no longer exists. Starting a capture on that node dies inside PipeWire, in the
+/// renderer, where nothing can catch it — so callers check first and fall back to the picker.
+/// Only a definite 0 justifies discarding a saved source; -1 means the check itself failed and
+/// the caller should proceed as it did before rather than throw the entry away.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_node_exists(node_id: u32) -> i32 {
+    guard_ffi("db_linux_node_exists", || {
+        if node_id == 0 {
+            return 0;
+        }
+        match node_exists(node_id) {
+            Ok(Some(true)) => 1,
+            Ok(Some(false)) => 0,
+            Ok(None) => {
+                log::warn!("node existence check for {node_id} timed out");
+                -1
+            }
+            Err(e) => {
+                log::warn!("node existence check for {node_id} failed: {e}");
+                -1
+            }
+        }
+    })
+}
+
 impl Drop for CaptureRuntime {
     fn drop(&mut self) {
         self.stop();

--- a/DesktopBuddyLinuxNative/src/portal_capture.rs
+++ b/DesktopBuddyLinuxNative/src/portal_capture.rs
@@ -1,0 +1,225 @@
+//! Pure ScreenCast capture sessions, separate from the RemoteDesktop input session.
+//!
+//! Binding ScreenCast to a RemoteDesktop session makes xdg-desktop-portal-kde treat screen
+//! sharing as a single `screenShareEnabled` flag over the whole workspace, so the picker
+//! offers exactly one source. A standalone ScreenCast session gets the real picker instead,
+//! with each monitor listed separately.
+//!
+//! The session has to stay alive for its PipeWire stream to remain valid, so each one owns a
+//! thread that parks until stopped and then closes the portal session explicitly.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::thread::{self, JoinHandle};
+
+use ashpd::desktop::{
+    screencast::{CursorMode, Screencast, SourceType},
+    PersistMode,
+};
+
+use crate::portal_input::set_last_error;
+
+struct CaptureSession {
+    stop_tx: async_channel::Sender<()>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl CaptureSession {
+    fn stop(&mut self) -> i32 {
+        let _ = self.stop_tx.try_send(());
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+        0
+    }
+}
+
+static CAPTURE_SESSIONS: OnceLock<Mutex<HashMap<u64, CaptureSession>>> = OnceLock::new();
+static NEXT_CAPTURE_SESSION_ID: AtomicU64 = AtomicU64::new(1);
+
+fn capture_sessions() -> &'static Mutex<HashMap<u64, CaptureSession>> {
+    CAPTURE_SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+struct CaptureInfo {
+    node_id: u32,
+    width: u32,
+    height: u32,
+    position_x: i32,
+    position_y: i32,
+    is_monitor: bool,
+    token: Option<String>,
+}
+
+/// Opens the ScreenCast picker (or restores silently when given a token) and keeps the
+/// resulting session alive until `db_linux_screencast_stop`.
+///
+/// Returns 0 on success, negative on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_screencast_start(
+    token_ptr: *const u8,
+    token_len: usize,
+    out_session_id: *mut u64,
+    out_selection: *mut crate::DbLinuxSelection,
+) -> i32 {
+    if out_session_id.is_null() {
+        return -1;
+    }
+    unsafe { *out_session_id = 0 };
+
+    let token: Option<String> = if token_ptr.is_null() || token_len == 0 {
+        None
+    } else {
+        let slice = unsafe { std::slice::from_raw_parts(token_ptr, token_len) };
+        std::str::from_utf8(slice).ok().map(|s| s.to_owned())
+    };
+
+    let (stop_tx, stop_rx) = async_channel::unbounded::<()>();
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<CaptureInfo, String>>();
+
+    let thread = thread::spawn(move || {
+        async_std::task::block_on(async move {
+            let screencast = match Screencast::new().await {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = ready_tx.send(Err(format!("Screencast::new: {e}")));
+                    return;
+                }
+            };
+
+            let session = match screencast.create_session().await {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = ready_tx.send(Err(format!("create_session: {e}")));
+                    return;
+                }
+            };
+
+            let info = match setup(&screencast, &session, token.as_deref()).await {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = session.close().await;
+                    let _ = ready_tx.send(Err(e));
+                    return;
+                }
+            };
+
+            let _ = ready_tx.send(Ok(info));
+
+            // Park until stopped; the session must outlive the stream.
+            let _ = stop_rx.recv().await;
+
+            if let Err(e) = session.close().await {
+                set_last_error(&format!("screencast session close: {e}"));
+            }
+        });
+    });
+
+    let info = match ready_rx.recv() {
+        Ok(Ok(info)) => info,
+        Ok(Err(e)) => {
+            set_last_error(&format!("screencast setup failed: {e}"));
+            let _ = thread.join();
+            return -2;
+        }
+        Err(_) => {
+            set_last_error("screencast setup thread ended without reporting a result");
+            return -3;
+        }
+    };
+
+    if !out_selection.is_null() {
+        let mut sel = crate::DbLinuxSelection {
+            node_id: info.node_id,
+            width: info.width.max(1),
+            height: info.height.max(1),
+            is_monitor: if info.is_monitor { 1 } else { 0 },
+            position_x: info.position_x,
+            position_y: info.position_y,
+            ..Default::default()
+        };
+        if let Some(token) = info.token.as_deref() {
+            let bytes = token.as_bytes();
+            let len = bytes.len().min(sel.restore_token.len());
+            sel.restore_token[..len].copy_from_slice(&bytes[..len]);
+            sel.restore_token_len = len as u32;
+        }
+        unsafe { *out_selection = sel };
+    }
+
+    let id = NEXT_CAPTURE_SESSION_ID.fetch_add(1, Ordering::Relaxed);
+    let mut map = match capture_sessions().lock() {
+        Ok(m) => m,
+        Err(_) => return -4,
+    };
+    map.insert(
+        id,
+        CaptureSession {
+            stop_tx,
+            thread: Some(thread),
+        },
+    );
+    unsafe { *out_session_id = id };
+    0
+}
+
+/// Stops a capture session and closes its portal session. Returns 0 on success, -1 if no
+/// such session was registered, -3 on lock poisoning.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_screencast_stop(session_id: u64) -> i32 {
+    match capture_sessions().lock() {
+        Ok(mut map) => match map.remove(&session_id) {
+            Some(mut s) => s.stop(),
+            None => -1,
+        },
+        Err(_) => -3,
+    }
+}
+
+async fn setup<'a>(
+    screencast: &Screencast<'a>,
+    session: &ashpd::desktop::Session<'a, Screencast<'a>>,
+    token: Option<&str>,
+) -> Result<CaptureInfo, String> {
+    screencast
+        .select_sources(
+            session,
+            CursorMode::Embedded,
+            // Windows are deliberately excluded. The portal exposes no window identity or
+            // geometry, so a window panel gets no name, no icon, and input that drifts as soon
+            // as the window is moved. Offering it in the picker only invites a broken share.
+            SourceType::Monitor | SourceType::Virtual,
+            false,
+            token,
+            PersistMode::ExplicitlyRevoked,
+        )
+        .await
+        .map_err(|e| format!("select_sources: {e}"))?;
+
+    let response = screencast
+        .start(session, None)
+        .await
+        .map_err(|e| format!("start: {e}"))?
+        .response()
+        .map_err(|e| format!("start response: {e}"))?;
+
+    let restore_token = response.restore_token().map(|s| s.to_owned());
+    let stream = response
+        .streams()
+        .first()
+        .ok_or_else(|| "no streams".to_string())?;
+
+    let (w, h) = stream.size().unwrap_or((0, 0));
+    let (x, y) = stream.position().unwrap_or((0, 0));
+
+    Ok(CaptureInfo {
+        node_id: stream.pipe_wire_node_id(),
+        width: w.max(0) as u32,
+        height: h.max(0) as u32,
+        position_x: x,
+        position_y: y,
+        is_monitor: matches!(stream.source_type(), Some(SourceType::Monitor)),
+        token: restore_token,
+    })
+}

--- a/DesktopBuddyLinuxNative/src/portal_input.rs
+++ b/DesktopBuddyLinuxNative/src/portal_input.rs
@@ -21,6 +21,7 @@ enum Msg {
     TouchUp { slot: u32 },
     Scroll { steps: i32 },
     Key { keysym: i32, pressed: bool },
+    Button { button: i32, pressed: bool },
     Stop,
 }
 
@@ -55,7 +56,7 @@ fn sessions() -> &'static Mutex<HashMap<u64, InputSession>> {
 
 static LAST_ERROR: OnceLock<Mutex<Option<CString>>> = OnceLock::new();
 
-fn set_last_error(msg: &str) {
+pub(crate) fn set_last_error(msg: &str) {
     let cell = LAST_ERROR.get_or_init(|| Mutex::new(None));
     if let Ok(mut guard) = cell.lock() {
         *guard = CString::new(msg).ok();
@@ -265,6 +266,16 @@ pub extern "C" fn db_linux_input_start(
                             set_last_error(&format!("notify_keyboard_keysym: {e}"));
                         }
                     }
+                    Msg::Button { button, pressed } => {
+                        let state = if pressed {
+                            KeyState::Pressed
+                        } else {
+                            KeyState::Released
+                        };
+                        if let Err(e) = remote.notify_pointer_button(&session, button, state).await {
+                            set_last_error(&format!("notify_pointer_button: {e}"));
+                        }
+                    }
                     Msg::Stop => break,
                 }
             }
@@ -368,6 +379,16 @@ pub extern "C" fn db_linux_input_scroll(session_id: u64, steps: i32) {
     send(session_id, Msg::Scroll { steps });
 }
 
+/// Presses or releases a pointer button. `button` is an evdev code: BTN_LEFT is 0x110,
+/// BTN_RIGHT 0x111, BTN_MIDDLE 0x112.
+///
+/// The rest of the input surface is touch-based, which has no notion of a secondary button;
+/// this is the only path that can produce a real right-click.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_input_button(session_id: u64, button: i32, pressed: i32) {
+    send(session_id, Msg::Button { button, pressed: pressed != 0 });
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn db_linux_input_key(session_id: u64, keysym: i32, pressed: i32) {
     send(
@@ -407,6 +428,90 @@ fn effect_name(ptr: *const u8, len: usize) -> Option<String> {
     }
     let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
     std::str::from_utf8(slice).ok().map(|s| s.to_owned())
+}
+
+/// Looks up the connector name (`DP-5`, `HDMI-A-1`, ...) of the output whose geometry matches
+/// the given rectangle, writing it into `out_buf` and returning its length.
+///
+/// The ScreenCast portal deliberately hands back only a node id and geometry, never an output
+/// name, so the name has to be recovered by matching that geometry against what the
+/// compositor reports. KWin's `supportInformation` is the only interface that exposes it.
+/// Returns 0 when no output matches, negative on error.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_kwin_output_name(
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    out_buf: *mut u8,
+    buf_len: usize,
+) -> i32 {
+    if out_buf.is_null() || buf_len == 0 {
+        return -1;
+    }
+
+    let info = match kwin_support_information() {
+        Ok(s) => s,
+        Err(e) => {
+            set_last_error(&format!("kwin_output_name: {e}"));
+            return -2;
+        }
+    };
+
+    let wanted = format!("{x},{y},{width}x{height}");
+    let Some(name) = find_output_named(&info, &wanted) else {
+        return 0;
+    };
+
+    let bytes = name.as_bytes();
+    let len = bytes.len().min(buf_len);
+    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf, len) };
+    len as i32
+}
+
+fn kwin_support_information() -> Result<String, String> {
+    async_std::task::block_on(async {
+        let connection = ashpd::zbus::Connection::session()
+            .await
+            .map_err(|e| format!("session bus: {e}"))?;
+
+        let reply = connection
+            .call_method(
+                Some("org.kde.KWin"),
+                "/KWin",
+                Some("org.kde.KWin"),
+                "supportInformation",
+                &(),
+            )
+            .await
+            .map_err(|e| format!("supportInformation: {e}"))?;
+
+        reply
+            .body()
+            .deserialize::<String>()
+            .map_err(|e| format!("supportInformation body: {e}"))
+    })
+}
+
+/// Pairs each `Name:` with the `Geometry:` that follows it and returns the matching name.
+///
+/// Entries that are not outputs (the backend's own `Name: DRM`, for instance) are followed by
+/// another `Name:` rather than a geometry, so they never match and drop out naturally.
+fn find_output_named(info: &str, wanted_geometry: &str) -> Option<String> {
+    let mut current: Option<String> = None;
+
+    for line in info.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("Name: ") {
+            current = Some(rest.trim().to_owned());
+        } else if let Some(rest) = line.strip_prefix("Geometry: ") {
+            if rest.trim() == wanted_geometry {
+                return current.clone();
+            }
+        }
+    }
+
+    None
 }
 
 /// Reports whether a KWin effect is currently loaded: 1 yes, 0 no, negative on error.
@@ -459,15 +564,35 @@ pub extern "C" fn db_linux_kwin_effect_set(name_ptr: *const u8, name_len: usize,
 /// token we are about to replace or forget has to be revoked here or it leaks forever.
 #[unsafe(no_mangle)]
 pub extern "C" fn db_linux_input_revoke_token(token_ptr: *const u8, token_len: usize) -> i32 {
-    if token_ptr.is_null() || token_len == 0 {
+    const TABLE: &str = "remote-desktop";
+    db_linux_portal_revoke_token(TABLE.as_ptr(), TABLE.len(), token_ptr, token_len)
+}
+
+/// Revokes a persisted grant from a named permission-store table.
+///
+/// RemoteDesktop grants land in `remote-desktop` and ScreenCast grants in `screencast`, so
+/// the table has to be chosen by the caller rather than assumed.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_portal_revoke_token(
+    table_ptr: *const u8,
+    table_len: usize,
+    token_ptr: *const u8,
+    token_len: usize,
+) -> i32 {
+    if token_ptr.is_null() || token_len == 0 || table_ptr.is_null() || table_len == 0 {
         return -1;
     }
 
-    let slice = unsafe { std::slice::from_raw_parts(token_ptr, token_len) };
-    let Ok(token) = std::str::from_utf8(slice) else {
+    let token_slice = unsafe { std::slice::from_raw_parts(token_ptr, token_len) };
+    let table_slice = unsafe { std::slice::from_raw_parts(table_ptr, table_len) };
+    let (Ok(token), Ok(table)) = (
+        std::str::from_utf8(token_slice),
+        std::str::from_utf8(table_slice),
+    ) else {
         return -2;
     };
     let token = token.to_owned();
+    let table = table.to_owned();
 
     async_std::task::block_on(async move {
         let connection = match ashpd::zbus::Connection::session().await {
@@ -484,13 +609,13 @@ pub extern "C" fn db_linux_input_revoke_token(token_ptr: *const u8, token_len: u
                 "/org/freedesktop/impl/portal/PermissionStore",
                 Some("org.freedesktop.impl.portal.PermissionStore"),
                 "Delete",
-                &("remote-desktop", token.as_str()),
+                &(table.as_str(), token.as_str()),
             )
             .await
         {
             Ok(_) => 0,
             Err(e) => {
-                set_last_error(&format!("revoke_token {token}: {e}"));
+                set_last_error(&format!("revoke_token {table}/{token}: {e}"));
                 -4
             }
         }

--- a/DesktopBuddyLinuxNative/src/portal_input.rs
+++ b/DesktopBuddyLinuxNative/src/portal_input.rs
@@ -24,17 +24,25 @@ enum Msg {
     Stop,
 }
 
+/// Outcome of the worker's `Session::close` call, so `db_linux_input_stop` can report
+/// whether the portal actually released the session rather than silently succeeding.
+const CLOSE_PENDING: i32 = 1;
+const CLOSE_OK: i32 = 0;
+const CLOSE_FAILED: i32 = -2;
+
 struct InputSession {
     tx: async_channel::Sender<Msg>,
     thread: Option<JoinHandle<()>>,
+    close_result: std::sync::Arc<std::sync::atomic::AtomicI32>,
 }
 
 impl InputSession {
-    fn stop(&mut self) {
+    fn stop(&mut self) -> i32 {
         let _ = self.tx.try_send(Msg::Stop);
         if let Some(t) = self.thread.take() {
             let _ = t.join();
         }
+        self.close_result.load(Ordering::SeqCst)
     }
 }
 
@@ -156,6 +164,9 @@ pub extern "C" fn db_linux_input_start(
     let (tx, rx) = async_channel::unbounded::<Msg>();
     let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<SessionInfo, String>>();
 
+    let close_result = std::sync::Arc::new(std::sync::atomic::AtomicI32::new(CLOSE_PENDING));
+    let close_slot = close_result.clone();
+
     let thread = thread::spawn(move || {
         async_std::task::block_on(async move {
             let remote = match RemoteDesktop::new().await {
@@ -184,6 +195,9 @@ pub extern "C" fn db_linux_input_start(
             {
                 Ok(v) => v,
                 Err(e) => {
+                    // The session exists from create_session above even though setup failed
+                    // (a cancelled picker lands here), so it needs closing like any other.
+                    let _ = session.close().await;
                     let _ = ready_tx.send(Err(e));
                     return;
                 }
@@ -255,6 +269,17 @@ pub extern "C" fn db_linux_input_start(
                 }
             }
 
+            // Dropping the Session does not end it: Close is a D-Bus call and Drop cannot
+            // await. ashpd reuses a cached session-bus connection that outlives this thread,
+            // so without this the portal keeps the session alive for the life of the process
+            // and the desktop environment leaves a screencast indicator behind for each share.
+            match session.close().await {
+                Ok(()) => close_slot.store(CLOSE_OK, Ordering::SeqCst),
+                Err(e) => {
+                    set_last_error(&format!("session close: {e}"));
+                    close_slot.store(CLOSE_FAILED, Ordering::SeqCst);
+                }
+            }
         });
     });
 
@@ -298,6 +323,7 @@ pub extern "C" fn db_linux_input_start(
         InputSession {
             tx,
             thread: Some(thread),
+            close_result,
         },
     );
     unsafe { *out_session_id = id };
@@ -353,11 +379,77 @@ pub extern "C" fn db_linux_input_key(session_id: u64, keysym: i32, pressed: i32)
     );
 }
 
+/// Revokes a persisted RemoteDesktop grant.
+///
+/// `select_devices` above uses `PersistMode::ExplicitlyRevoked`, which is what lets a saved
+/// source be re-shared without a dialog. The cost is that every grant outlives the process
+/// and stays in the desktop's remembered-permissions list until something deletes it, so a
+/// token we are about to replace or forget has to be revoked here or it leaks forever.
 #[unsafe(no_mangle)]
-pub extern "C" fn db_linux_input_stop(session_id: u64) {
-    if let Ok(mut map) = sessions().lock() {
-        if let Some(mut s) = map.remove(&session_id) {
-            s.stop();
+pub extern "C" fn db_linux_input_revoke_token(token_ptr: *const u8, token_len: usize) -> i32 {
+    if token_ptr.is_null() || token_len == 0 {
+        return -1;
+    }
+
+    let slice = unsafe { std::slice::from_raw_parts(token_ptr, token_len) };
+    let Ok(token) = std::str::from_utf8(slice) else {
+        return -2;
+    };
+    let token = token.to_owned();
+
+    async_std::task::block_on(async move {
+        let connection = match ashpd::zbus::Connection::session().await {
+            Ok(c) => c,
+            Err(e) => {
+                set_last_error(&format!("revoke_token: session bus: {e}"));
+                return -3;
+            }
+        };
+
+        match connection
+            .call_method(
+                Some("org.freedesktop.impl.portal.PermissionStore"),
+                "/org/freedesktop/impl/portal/PermissionStore",
+                Some("org.freedesktop.impl.portal.PermissionStore"),
+                "Delete",
+                &("remote-desktop", token.as_str()),
+            )
+            .await
+        {
+            Ok(_) => 0,
+            Err(e) => {
+                set_last_error(&format!("revoke_token {token}: {e}"));
+                -4
+            }
         }
+    })
+}
+
+/// Stops a session and reports what actually happened, so a portal session that was never
+/// released does not look identical to a clean shutdown from the caller's side.
+///
+/// Returns 0 when the portal confirmed the close, 1 if the worker ended without reaching it,
+/// -1 if no such session was registered, -2 if the close call itself failed, -3 on lock
+/// poisoning.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_input_stop(session_id: u64) -> i32 {
+    match sessions().lock() {
+        Ok(mut map) => match map.remove(&session_id) {
+            Some(mut s) => s.stop(),
+            None => {
+                // An empty map means the library was unloaded and reloaded between start and
+                // stop, taking these statics (and the worker threads) with it. A populated map
+                // means something else already removed this id. The two need different fixes.
+                let ids: Vec<String> = map.keys().map(|k| k.to_string()).collect();
+                set_last_error(&format!(
+                    "input_stop: session {session_id} not registered; map holds {} session(s): [{}]; next_id={}",
+                    ids.len(),
+                    ids.join(","),
+                    NEXT_SESSION_ID.load(Ordering::Relaxed)
+                ));
+                -1
+            }
+        },
+        Err(_) => -3,
     }
 }

--- a/DesktopBuddyLinuxNative/src/portal_input.rs
+++ b/DesktopBuddyLinuxNative/src/portal_input.rs
@@ -379,6 +379,78 @@ pub extern "C" fn db_linux_input_key(session_id: u64, keysym: i32, pressed: i32)
     );
 }
 
+fn kwin_effect_call(method: &str, effect: &str) -> Result<bool, String> {
+    async_std::task::block_on(async {
+        let connection = ashpd::zbus::Connection::session()
+            .await
+            .map_err(|e| format!("session bus: {e}"))?;
+
+        let reply = connection
+            .call_method(
+                Some("org.kde.KWin"),
+                "/Effects",
+                Some("org.kde.kwin.Effects"),
+                method,
+                &(effect,),
+            )
+            .await
+            .map_err(|e| format!("{method}: {e}"))?;
+
+        // loadEffect/unloadEffect return nothing; only isEffectLoaded carries a body.
+        Ok(reply.body().deserialize::<bool>().unwrap_or(true))
+    })
+}
+
+fn effect_name(ptr: *const u8, len: usize) -> Option<String> {
+    if ptr.is_null() || len == 0 {
+        return None;
+    }
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    std::str::from_utf8(slice).ok().map(|s| s.to_owned())
+}
+
+/// Reports whether a KWin effect is currently loaded: 1 yes, 0 no, negative on error.
+///
+/// Used to suspend KWin's `shakecursor` effect while a desktop is shared. Injected pointer
+/// motion and the user's real mouse fight over the cursor, which KWin reads as shaking and
+/// responds to by magnifying the cursor.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_kwin_effect_loaded(name_ptr: *const u8, name_len: usize) -> i32 {
+    let Some(name) = effect_name(name_ptr, name_len) else {
+        return -1;
+    };
+
+    match kwin_effect_call("isEffectLoaded", &name) {
+        Ok(true) => 1,
+        Ok(false) => 0,
+        Err(e) => {
+            set_last_error(&format!("kwin_effect_loaded: {e}"));
+            -2
+        }
+    }
+}
+
+/// Loads (`load` non-zero) or unloads a KWin effect. Returns 0 on success.
+///
+/// This is deliberately a runtime-only change rather than a kwinrc edit: if Resonite dies
+/// while an effect is suspended, the user's configuration is untouched and the effect comes
+/// back on the next KWin reconfigure or restart.
+#[unsafe(no_mangle)]
+pub extern "C" fn db_linux_kwin_effect_set(name_ptr: *const u8, name_len: usize, load: i32) -> i32 {
+    let Some(name) = effect_name(name_ptr, name_len) else {
+        return -1;
+    };
+
+    let method = if load != 0 { "loadEffect" } else { "unloadEffect" };
+    match kwin_effect_call(method, &name) {
+        Ok(_) => 0,
+        Err(e) => {
+            set_last_error(&format!("kwin_effect_set: {e}"));
+            -2
+        }
+    }
+}
+
 /// Revokes a persisted RemoteDesktop grant.
 ///
 /// `select_devices` above uses `PersistMode::ExplicitlyRevoked`, which is what lets a saved

--- a/DesktopBuddySharedTextureBridge/LinuxCaptureGuard.cs
+++ b/DesktopBuddySharedTextureBridge/LinuxCaptureGuard.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Globalization;
+using System.IO;
+using BepInEx.Logging;
+
+namespace DesktopBuddySharedTextureBridge
+{
+    /// <summary>
+    /// Crash-loop breaker for the Linux native capture start.
+    ///
+    /// Starting a PipeWire capture runs unmanaged code inside the Wine renderer. If that
+    /// call faults, the renderer dies outright and FrooxEngine follows it down with a
+    /// FORCE CRASH, so there is no managed exception to catch and no way to recover in
+    /// process. Instead we record that a start was in flight, on disk, before making the
+    /// call. A start that never completes leaves the marker behind, and after enough
+    /// consecutive losses we stop attempting the native path at all: the desktop panel
+    /// stays blank, but the session survives.
+    /// </summary>
+    internal static class LinuxCaptureGuard
+    {
+        private const int DisableThreshold = 2;
+        private const string GuardFileName = "linux-capture.guard";
+
+        private static ManualLogSource _log;
+        private static string _path;
+        private static int _failures;
+
+        /// <summary>True when repeated crashes have taken the native capture path out of service.</summary>
+        internal static bool NativeCaptureDisabled { get; private set; }
+
+        internal static void Initialize(ManualLogSource log)
+        {
+            _log = log;
+
+            try
+            {
+                string dir = Path.GetDirectoryName(typeof(LinuxCaptureGuard).Assembly.Location);
+                if (string.IsNullOrEmpty(dir))
+                    return;
+
+                _path = Path.Combine(dir, GuardFileName);
+                _failures = ReadFailureCount();
+
+                if (_failures <= 0)
+                    return;
+
+                if (_failures >= DisableThreshold)
+                {
+                    NativeCaptureDisabled = true;
+                    _log?.LogError(
+                        $"[LinuxCapture] Native capture disabled: the renderer died during capture start {_failures} times in a row. " +
+                        $"Desktop panels will stay blank this session. Delete '{_path}' to re-enable.");
+                }
+                else
+                {
+                    _log?.LogWarning(
+                        $"[LinuxCapture] Previous renderer session died during capture start (strike {_failures} of {DisableThreshold}); retrying.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _log?.LogWarning($"[LinuxCapture] Guard init failed, continuing unguarded: {ex.Message}");
+            }
+        }
+
+        /// <summary>Records that a native start is about to run. Returns false if the path is out of service.</summary>
+        internal static bool BeginNativeStart(uint nodeId)
+        {
+            if (NativeCaptureDisabled)
+            {
+                _log?.LogError($"[LinuxCapture] Refusing native capture start for node={nodeId}: path disabled after repeated crashes.");
+                return false;
+            }
+
+            WriteFailureCount(_failures + 1);
+            return true;
+        }
+
+        /// <summary>Clears the in-flight marker once the native call has returned, however it returned.</summary>
+        internal static void EndNativeStart()
+        {
+            // Surviving the call is what matters here, not the status code it produced:
+            // a clean failure is reported through normal channels and is not a crash.
+            _failures = 0;
+            try
+            {
+                if (_path != null && File.Exists(_path))
+                    File.Delete(_path);
+            }
+            catch (Exception ex)
+            {
+                _log?.LogWarning($"[LinuxCapture] Could not clear guard marker: {ex.Message}");
+            }
+        }
+
+        private static int ReadFailureCount()
+        {
+            try
+            {
+                if (_path == null || !File.Exists(_path))
+                    return 0;
+
+                string text = File.ReadAllText(_path).Trim();
+                return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int count) && count > 0
+                    ? count
+                    : 1;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private static void WriteFailureCount(int count)
+        {
+            try
+            {
+                if (_path == null)
+                    return;
+
+                File.WriteAllText(_path, count.ToString(CultureInfo.InvariantCulture));
+            }
+            catch (Exception ex)
+            {
+                _log?.LogWarning($"[LinuxCapture] Could not write guard marker: {ex.Message}");
+            }
+        }
+    }
+}

--- a/DesktopBuddySharedTextureBridge/LinuxCaptureGuard.cs
+++ b/DesktopBuddySharedTextureBridge/LinuxCaptureGuard.cs
@@ -15,15 +15,26 @@ namespace DesktopBuddySharedTextureBridge
     /// call. A start that never completes leaves the marker behind, and after enough
     /// consecutive losses we stop attempting the native path at all: the desktop panel
     /// stays blank, but the session survives.
+    ///
+    /// The marker also carries the stage the start had reached. Unity buffers its log, so an
+    /// abort can swallow the last lines written before it; a file write is a side effect that
+    /// survives, which is what makes the stage trustworthy after the fact.
     /// </summary>
     internal static class LinuxCaptureGuard
     {
         private const int DisableThreshold = 2;
         private const string GuardFileName = "linux-capture.guard";
 
+        /// <summary>Loading the native library, which pulls PipeWire into the Wine process.</summary>
+        internal const string StageLoad = "load";
+
+        /// <summary>Connecting the capture to its PipeWire node.</summary>
+        internal const string StageConnect = "connect";
+
         private static ManualLogSource _log;
         private static string _path;
         private static int _failures;
+        private static string _lastStage;
 
         /// <summary>True when repeated crashes have taken the native capture path out of service.</summary>
         internal static bool NativeCaptureDisabled { get; private set; }
@@ -39,22 +50,24 @@ namespace DesktopBuddySharedTextureBridge
                     return;
 
                 _path = Path.Combine(dir, GuardFileName);
-                _failures = ReadFailureCount();
+                _failures = ReadMarker(out _lastStage);
 
                 if (_failures <= 0)
                     return;
+
+                string stage = _lastStage != null ? $" while it was in the '{_lastStage}' stage" : string.Empty;
 
                 if (_failures >= DisableThreshold)
                 {
                     NativeCaptureDisabled = true;
                     _log?.LogError(
-                        $"[LinuxCapture] Native capture disabled: the renderer died during capture start {_failures} times in a row. " +
+                        $"[LinuxCapture] Native capture disabled: the renderer died during capture start {_failures} times in a row{stage}. " +
                         $"Desktop panels will stay blank this session. Delete '{_path}' to re-enable.");
                 }
                 else
                 {
                     _log?.LogWarning(
-                        $"[LinuxCapture] Previous renderer session died during capture start (strike {_failures} of {DisableThreshold}); retrying.");
+                        $"[LinuxCapture] Previous renderer session died during capture start{stage} (strike {_failures} of {DisableThreshold}); retrying.");
                 }
             }
             catch (Exception ex)
@@ -72,8 +85,17 @@ namespace DesktopBuddySharedTextureBridge
                 return false;
             }
 
-            WriteFailureCount(_failures + 1);
+            WriteMarker(_failures + 1, StageLoad);
             return true;
+        }
+
+        /// <summary>
+        /// Updates the in-flight marker to name the stage now running, so a renderer that dies
+        /// here is attributed to that stage rather than to the start as a whole.
+        /// </summary>
+        internal static void MarkStage(string stage)
+        {
+            WriteMarker(_failures + 1, stage);
         }
 
         /// <summary>Clears the in-flight marker once the native call has returned, however it returned.</summary>
@@ -93,32 +115,48 @@ namespace DesktopBuddySharedTextureBridge
             }
         }
 
-        private static int ReadFailureCount()
+        /// <summary>
+        /// Reads the marker, which holds a failure count optionally followed by ':' and the stage
+        /// that was in flight. Markers written before the stage was recorded are still just a
+        /// count, so the stage is reported as unknown rather than treated as a parse failure.
+        /// </summary>
+        private static int ReadMarker(out string stage)
         {
+            stage = null;
             try
             {
                 if (_path == null || !File.Exists(_path))
                     return 0;
 
                 string text = File.ReadAllText(_path).Trim();
+                int separator = text.IndexOf(':');
+                if (separator >= 0)
+                {
+                    string suffix = text.Substring(separator + 1).Trim();
+                    if (suffix.Length > 0)
+                        stage = suffix;
+                    text = text.Substring(0, separator);
+                }
+
                 return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int count) && count > 0
                     ? count
                     : 1;
             }
             catch
             {
+                stage = null;
                 return 0;
             }
         }
 
-        private static void WriteFailureCount(int count)
+        private static void WriteMarker(int count, string stage)
         {
             try
             {
                 if (_path == null)
                     return;
 
-                File.WriteAllText(_path, count.ToString(CultureInfo.InvariantCulture));
+                File.WriteAllText(_path, $"{count.ToString(CultureInfo.InvariantCulture)}:{stage}");
             }
             catch (Exception ex)
             {

--- a/DesktopBuddySharedTextureBridge/LinuxCaptureTextureSlot.cs
+++ b/DesktopBuddySharedTextureBridge/LinuxCaptureTextureSlot.cs
@@ -68,8 +68,22 @@ namespace DesktopBuddySharedTextureBridge
             if (_captureStarted || _disposed)
                 return;
 
+            if (!LinuxCaptureGuard.BeginNativeStart(_pipeWireNodeId))
+            {
+                _captureStarted = false;
+                return;
+            }
+
             SharedTextureBridgePlugin.LogInfo($"[LinuxCapture] SHM capture start calling native bridge node={_pipeWireNodeId}");
-            int status = _bridge.StartCapture(_pipeWireNodeId);
+            int status;
+            try
+            {
+                status = _bridge.StartCapture(_pipeWireNodeId);
+            }
+            finally
+            {
+                LinuxCaptureGuard.EndNativeStart();
+            }
             SharedTextureBridgePlugin.LogInfo($"[LinuxCapture] SHM capture start returned {status} node={_pipeWireNodeId}");
             if (status != 0)
                 SharedTextureBridgePlugin.LogWarning($"[LinuxCapture] SHM capture did not start cleanly: {status}");

--- a/DesktopBuddySharedTextureBridge/LinuxCaptureTextureSlot.cs
+++ b/DesktopBuddySharedTextureBridge/LinuxCaptureTextureSlot.cs
@@ -74,17 +74,28 @@ namespace DesktopBuddySharedTextureBridge
                 return;
             }
 
-            SharedTextureBridgePlugin.LogInfo($"[LinuxCapture] SHM capture start calling native bridge node={_pipeWireNodeId}");
+            // Both stages run unmanaged code that can take the renderer down, so both stay inside
+            // the guard. They are issued separately only so the marker can name which one lost.
             int status;
             try
             {
-                status = _bridge.StartCapture(_pipeWireNodeId);
+                SharedTextureBridgePlugin.LogInfo($"[LinuxCapture] Loading native capture library node={_pipeWireNodeId}");
+                status = _bridge.LoadNative();
+                SharedTextureBridgePlugin.LogInfo($"[LinuxCapture] Native capture library load returned {status}");
+
+                if (status == 0)
+                {
+                    LinuxCaptureGuard.MarkStage(LinuxCaptureGuard.StageConnect);
+                    SharedTextureBridgePlugin.LogInfo($"[LinuxCapture] SHM capture start calling native bridge node={_pipeWireNodeId}");
+                    status = _bridge.StartCapture(_pipeWireNodeId);
+                    SharedTextureBridgePlugin.LogInfo($"[LinuxCapture] SHM capture start returned {status} node={_pipeWireNodeId}");
+                }
             }
             finally
             {
                 LinuxCaptureGuard.EndNativeStart();
             }
-            SharedTextureBridgePlugin.LogInfo($"[LinuxCapture] SHM capture start returned {status} node={_pipeWireNodeId}");
+
             if (status != 0)
                 SharedTextureBridgePlugin.LogWarning($"[LinuxCapture] SHM capture did not start cleanly: {status}");
 

--- a/DesktopBuddySharedTextureBridge/LinuxCaptureTextureSlot.cs
+++ b/DesktopBuddySharedTextureBridge/LinuxCaptureTextureSlot.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using BepInEx.Logging;
 using UnityEngine;
@@ -7,6 +8,12 @@ namespace DesktopBuddySharedTextureBridge
 {
     internal sealed class LinuxCaptureTextureSlot : IBridgeTextureSlot
     {
+        /// <summary>
+        /// Frames a texture retired on teardown is kept alive before it is destroyed. Matches the
+        /// deferral the shared-texture path uses for its native handles.
+        /// </summary>
+        private const int DeferredDestroyFrames = 3;
+
         private const uint DrmFormatArgb8888 = 0x34325241;
         private const uint DrmFormatXrgb8888 = 0x34325258;
         private const uint DrmFormatAbgr8888 = 0x34324241;
@@ -240,11 +247,42 @@ namespace DesktopBuddySharedTextureBridge
             if (_disposed) return;
             _disposed = true;
 
-            DestroyTexture();
+            RetireTexture();
             _bridge.Dispose();
             _requests.Clear();
         }
 
+        /// <summary>
+        /// Hands the texture to the deferred queue rather than destroying it here.
+        /// </summary>
+        /// <remarks>
+        /// Teardown is the one case where no replacement texture is published: the slot is being
+        /// unregistered, so a consumer that still holds this source for the rest of the frame has
+        /// nothing valid to re-read. Renderite's own <c>DuplicableDisplay.UnregisterRequest</c>
+        /// hit this and responded by never destroying the texture at all, commenting the call out
+        /// with "destroying and recreating it causes issues". It can afford that because it keeps
+        /// one texture per monitor; slots here come and go with every share, so holding them
+        /// forever would leak a full-resolution texture per share. Deferring instead keeps the
+        /// texture alive past any in-flight reference without growing without bound.
+        /// </remarks>
+        private void RetireTexture()
+        {
+            if (_texture == null)
+                return;
+
+            DeferredDestroys.Enqueue(new DeferredTextureDestroy
+            {
+                Texture = _texture,
+                FramesRemaining = DeferredDestroyFrames
+            });
+            _texture = null;
+        }
+
+        /// <summary>
+        /// Destroys the texture immediately. Only safe where a valid replacement is published in
+        /// the same call, which is what the resize path does — and what Renderite's own display
+        /// driver does for the same reason.
+        /// </summary>
         private void DestroyTexture()
         {
             if (_texture == null)
@@ -253,6 +291,36 @@ namespace DesktopBuddySharedTextureBridge
             try { UnityEngine.Object.Destroy(_texture); }
             catch (Exception ex) { SharedTextureBridgePlugin.LogWarning($"[LinuxCapture] Texture destroy failed: {ex.Message}"); }
             _texture = null;
+        }
+
+        private struct DeferredTextureDestroy
+        {
+            public Texture2D Texture;
+            public int FramesRemaining;
+        }
+
+        private static readonly ConcurrentQueue<DeferredTextureDestroy> DeferredDestroys =
+            new ConcurrentQueue<DeferredTextureDestroy>();
+
+        /// <summary>Destroys retired textures whose deferral has elapsed. Main thread only.</summary>
+        internal static void ProcessDeferredTextureDestroys()
+        {
+            int count = DeferredDestroys.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (!DeferredDestroys.TryDequeue(out var pending))
+                    return;
+
+                pending.FramesRemaining--;
+                if (pending.FramesRemaining > 0)
+                {
+                    DeferredDestroys.Enqueue(pending);
+                    continue;
+                }
+
+                try { UnityEngine.Object.Destroy(pending.Texture); }
+                catch (Exception ex) { SharedTextureBridgePlugin.LogWarning($"[LinuxCapture] Deferred texture destroy failed: {ex.Message}"); }
+            }
         }
 
         private void NotifyCallbacks()

--- a/DesktopBuddySharedTextureBridge/LinuxNativeBridgeRenderer.cs
+++ b/DesktopBuddySharedTextureBridge/LinuxNativeBridgeRenderer.cs
@@ -11,6 +11,7 @@ namespace DesktopBuddySharedTextureBridge
         private const uint OpStartNode = 6;
         private const uint OpCopyFrame = 7;
         private const uint OpCloseFrame = 8;
+        private const uint OpLoad = 9;
 
         private static readonly object LoadLock = new object();
         private static IntPtr SharedModule;
@@ -50,6 +51,18 @@ namespace DesktopBuddySharedTextureBridge
                 _call = SharedCall;
             }
             return true;
+        }
+
+        /// <summary>
+        /// Performs the native library load that every other op would otherwise do lazily on
+        /// first use. Splitting it out means a renderer that dies on the first capture attempt
+        /// tells us whether it died pulling PipeWire into the Wine process or connecting to it.
+        /// </summary>
+        internal int LoadNative()
+        {
+            if (!TryLoad()) return -1;
+            var call = new DbLinuxBridgeCall { Op = OpLoad };
+            return _call(ref call);
         }
 
         internal int StartCapture(uint nodeId)

--- a/DesktopBuddySharedTextureBridge/SharedTextureBridge.cs
+++ b/DesktopBuddySharedTextureBridge/SharedTextureBridge.cs
@@ -53,6 +53,7 @@ namespace DesktopBuddySharedTextureBridge
         internal void Update()
         {
             SharedTextureSlot.ProcessDeferredNativeReleases();
+            LinuxCaptureTextureSlot.ProcessDeferredTextureDestroys();
             TryEnsureMessenger();
             TryPublishRendererDevice();
 

--- a/DesktopBuddySharedTextureBridge/SharedTextureBridgePlugin.cs
+++ b/DesktopBuddySharedTextureBridge/SharedTextureBridgePlugin.cs
@@ -17,6 +17,8 @@ namespace DesktopBuddySharedTextureBridge
             Log = Logger;
             LogInfo("DesktopBuddySharedTextureBridge starting...");
 
+            LinuxCaptureGuard.Initialize(Log);
+
             try
             {
                 new Harmony("net.desktopbuddy.sharedtexturebridge").PatchAll();

--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ busctl --user call org.freedesktop.impl.portal.PermissionStore \
   org.freedesktop.impl.portal.PermissionStore List s remote-desktop
 ```
 
+#### Cursor magnification on KDE
+
+While a panel is shared, two things drive one pointer: DesktopBuddy injecting motion where your laser points, and your real mouse. The cursor snaps between the two positions many times a second, and KWin's **"Shake cursor to find it"** effect — on by default in Plasma 6 — reads that as shaking and magnifies the cursor, growing it further the longer it continues.
+
+DesktopBuddy handles this for you: it unloads KWin's `shakecursor` effect while any panel is shared and restores it once the last one closes. It only restores what it actually suspended, so an effect you had already turned off stays off. The effect is unloaded at runtime rather than disabled in `kwinrc`, so if Resonite crashes mid-share your configuration is untouched and the effect returns on the next KWin restart or reconfigure.
+
+Set `linuxSuspendShakeCursor = false` in the mod config if you would rather DesktopBuddy left your compositor alone. To restore the effect by hand:
+
+```sh
+qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.loadEffect shakecursor
+```
+
+This applies to KWin only; other compositors have no such effect and DesktopBuddy does nothing there.
+
 
 ## Features
 - Spawn full desktops or monitors (and individual application windows on Windows) as grabbable curved panels.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ sudo pacman -S ffmpeg v4l2loopback-dkms cloudflared
 
 PipeWire and xdg-desktop-portal (used for screen capture) ship with most modern Wayland desktops. After installing `v4l2loopback`, open Devices → "Virtual camera setup" in-world to load and configure the camera module.
 
+Is is also important to add the following WINEDLLOVERRIDES as a prefix under your steam launch options:
+```
+WINEDLLOVERRIDES="winhttp=n,b" %command%
+```
+
+
 ## Features
 - Spawn full desktops or monitors (and individual application windows on Windows) as grabbable curved panels.
 - Interact with captured panels using VR controllers, hand tracking, or touch input.

--- a/README.md
+++ b/README.md
@@ -65,16 +65,53 @@ sudo pacman -S ffmpeg v4l2loopback-dkms cloudflared
 
 PipeWire and xdg-desktop-portal (used for screen capture) ship with most modern Wayland desktops. After installing `v4l2loopback`, open Devices → "Virtual camera setup" in-world to load and configure the camera module.
 
-Is is also important to add the following WINEDLLOVERRIDES as a prefix under your steam launch options:
+#### Renderer-side mod loading (required)
+
+You must add the following prefix to your Steam launch options for Resonite:
+
 ```
 WINEDLLOVERRIDES="winhttp=n,b" %command%
+```
+
+If you already have launch options, keep them after `%command%`, for example:
+
+```
+WINEDLLOVERRIDES="winhttp=n,b" %command% -SkipIntroTutorial
+```
+
+**This goes in Steam's launch options even if you launch from Gale.** Gale's default launch mode shells out to `steam -applaunch`, so Steam is still what builds the Proton environment, and both sets of arguments are merged.
+
+Why it is needed: on Linux, Resonite splits into a **native** host process and a **Windows renderer running under Proton**. The host gets its mods through BepisLoader, but the renderer is a Windows process, so its mods load through Doorstop's `winhttp.dll` proxy — and Wine only prefers that file over its own built-in `winhttp` when you set the override above.
+
+Without it, DesktopBuddy still loads, still appears on the dial, and the portal picker still works, so nothing looks obviously broken — but `DesktopBuddySharedTextureBridge` never loads in the renderer, so **captured panels stay blank forever**. The give-away in the host log is an endless repeat of:
+
+```
+[UpdateLoop] Waiting for shared texture bind before applying DisplayIndex=... slot=...
+```
+
+To confirm the override took effect, launch once and check that this file exists:
+
+```text
+<profile>/Renderer/BepInEx/LogOutput.log
+```
+
+If that file is missing, Doorstop never injected and the override is not being applied.
+
+#### Screen-sharing permissions
+
+DesktopBuddy asks the desktop portal to remember your selection so a shared source can be re-shared without a picker dialog every time. On KDE this appears in the remembered screen-sharing permissions list. DesktopBuddy revokes each grant once it is superseded or the saved source is removed, so you should see at most one entry per remembered source rather than one per share. You can inspect the list with:
+
+```sh
+busctl --user call org.freedesktop.impl.portal.PermissionStore \
+  /org/freedesktop/impl/portal/PermissionStore \
+  org.freedesktop.impl.portal.PermissionStore List s remote-desktop
 ```
 
 
 ## Features
 - Spawn full desktops or monitors (and individual application windows on Windows) as grabbable curved panels.
 - Interact with captured panels using VR controllers, hand tracking, or touch input.
-- Fully GPU-accelerated desktop capture — Windows Graphics Capture on Windows, PipeWire / xdg-desktop-portal on Linux.
+- Fully GPU-accelerated desktop capture on Windows via Windows Graphics Capture. On Linux, capture uses PipeWire / xdg-desktop-portal, currently with a CPU copy on the renderer-side path (see Linux prerequisites).
 - Stream panels to other users through local encoding and remote HTTPS tunnel support.
 - Virtual video camera (DirectShow on Windows, v4l2loopback on Linux) so you can do video calls from within Resonite.
 - Virtual microphone driver (Windows) so friends can hear you in calls in Resonite.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -156,6 +156,15 @@ deploy_profile() {
   copy_file "$linux_bridge_dir/libdesktopbuddy_linux_native.so" "$bridge_target/libdesktopbuddy_linux_native.so"
   copy_file "$linux_bridge_dir/libdesktopbuddy_linux_stream.so" "$bridge_target/libdesktopbuddy_linux_stream.so"
 
+  # The guard's strike count describes the binaries that crashed, and the copies above just
+  # replaced them. Keeping it would have a fresh build — quite possibly the fix — refuse to
+  # attempt native capture at all, with only a startup log line to say why.
+  local capture_guard="$bridge_target/linux-capture.guard"
+  if [[ -f "$capture_guard" ]]; then
+    echo "Cleared Linux capture guard from a previous crash: $capture_guard"
+    rm -f "$capture_guard"
+  fi
+
   rm -f \
     "$profile_path/BepInEx/cache/chainloader_typeloader.dat" \
     "$profile_path/Renderer/BepInEx/cache/chainloader_typeloader.dat"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 configuration="Release"
-profile_path="${DESKTOPBUDDY_PROFILE_PATH:-/home/devl0rd/.local/share/com.kesomannen.gale/resonite/profiles/Default}"
+profile_path="${DESKTOPBUDDY_PROFILE_PATH:-$HOME/.local/share/com.kesomannen.gale/resonite/profiles/Default}"
 no_deploy=0
 restart=0
 resonite_appid="${RESONITE_APPID:-2519830}"


### PR DESCRIPTION
Includes changes to:
1) get desktop buddy working on my linux setup and document what config was needed, added a bunch of crash guards 
2) Fix accumulation of share indicators in the tray
3) Fix large cursor issue when mousing and lasing at same time by disabling KDE cursor shake while sharing
4) Can now share separate screens (not just whole desktop)
5) Mouse behaviour defaults to mouse (not touchscreen) option to switch back
6) Added a "pin" on the desktopbuddy dash to disable grab, and enable grab as right click
7) added a spawn tilt option

As such DB is working well for me now on arch linux. 
